### PR TITLE
fix: Make deploy script work without service_account.json file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,58 @@
+# ==========================================
+# School Agent v2 環境変数設定
+# ==========================================
+# このファイルを .env にコピーして使用してください
+# cp .env.example .env
+
+# ==========================================
+# 必須設定
+# ==========================================
+
+# Google Cloud Project ID
+PROJECT_ID=your-gcp-project-id
+
+# Google Sheets ID（設定用スプレッドシート）
+SPREADSHEET_ID=your-google-sheets-id
+
+# Google Drive Folder IDs
+INBOX_FOLDER_ID=your-drive-inbox-folder-id
+ARCHIVE_FOLDER_ID=your-drive-archive-folder-id
+
+# ==========================================
+# デプロイ設定（deploy_v2.sh使用時）
+# ==========================================
+
+# Service Account Email（オプション）
+# 未設定の場合は以下の順で自動検出:
+# 1. service_account.json から抽出
+# 2. gcloud コマンドでプロジェクトのService Accountを取得
+SERVICE_ACCOUNT_EMAIL=your-service-account@your-project.iam.gserviceaccount.com
+
+# ==========================================
+# オプショナル設定（未設定の場合はスキップ）
+# ==========================================
+
+# Todoist API Token
+# https://todoist.com/prefs/integrations から取得
+TODOIST_API_TOKEN=your-todoist-api-token
+
+# Slack Bot Token
+# https://api.slack.com/apps から取得
+SLACK_BOT_TOKEN=xoxb-your-slack-bot-token
+
+# Slack Channel ID
+# チャンネルを右クリック → "リンクをコピー" の最後の部分
+SLACK_CHANNEL_ID=C01234567
+
+# ==========================================
+# デフォルト値あり（通常変更不要）
+# ==========================================
+
+# Vertex AI Location
+VERTEX_AI_LOCATION=us-central1
+
+# Gemini Model
+GEMINI_MODEL=gemini-2.5-pro
+
+# ログレベル（DEBUG, INFO, WARNING, ERROR）
+LOG_LEVEL=INFO

--- a/v2/README.md
+++ b/v2/README.md
@@ -224,6 +224,20 @@ gcloud scheduler jobs create http school-agent-daily \
 - 新しいストレージ: `FileStorage` ABCを実装するだけ
 - 新しいLLM: `DocumentAnalyzer` ABCを実装するだけ
 
+### Service Account の設定
+
+デプロイスクリプトは以下の順でService Accountを検出します:
+
+1. **環境変数** `SERVICE_ACCOUNT_EMAIL` が設定されている場合はそれを使用
+2. **ローカルファイル** `service_account.json` が存在する場合はそこから抽出
+3. **gcloud コマンド** プロジェクトのService Accountを自動取得
+
+推奨: `.env` に `SERVICE_ACCOUNT_EMAIL` を設定
+
+```bash
+SERVICE_ACCOUNT_EMAIL=your-sa@your-project.iam.gserviceaccount.com
+```
+
 ### 既存デプロイから allUsers 権限を削除
 
 既にデプロイ済みのFunctionから`allUsers`権限を削除する方法:


### PR DESCRIPTION
## Summary
- `service_account.json`ファイルへの依存を削除し、複数の方法でService Accountを検出できるように改善
- 環境変数、ローカルファイル、gcloud自動取得の3段階フォールバック機構を実装

## Changes
- `deploy_v2.sh`: 3つの方法でService Accountメールを取得
  1. 環境変数 `SERVICE_ACCOUNT_EMAIL`（優先）
  2. `service_account.json` ファイル（既存の動作を維持）
  3. `gcloud` コマンドで自動取得（フォールバック）
- `.env.example`: `SERVICE_ACCOUNT_EMAIL` の設定例を追加
- `v2/README.md`: Service Account設定方法のドキュメントを追加

## Problem Fixed
以前のデプロイスクリプトは`service_account.json`ファイルに完全依存していたため、以下の環境でデプロイできませんでした:
- `git clone` 直後（ファイルが`.gitignore`に含まれるため）
- CI/CD環境
- 環境変数ベースの認証を使用する環境

## Test plan
- [ ] 環境変数で`SERVICE_ACCOUNT_EMAIL`を設定してデプロイ
- [ ] `service_account.json`ファイルを使用してデプロイ
- [ ] ファイルも環境変数もない状態で、gcloud自動取得でデプロイ
- [ ] デプロイ後、Cloud Functionsが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)