### PR TITLE
takt: # タスク指示書: GCP Artifact Registry のTerraform実装

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.20.0"
+  constraints = ">= 5.0.0"
+  hashes = [
+    "h1:xAH7d06AQkxPcBbQCakO8JH4gHt1tVHlwDWX7ajcRRY=",
+    "zh:0476beff4009352c52e4595c20beb21b0d5e20ebf3d86753df1ea4b655fdb000",
+    "zh:25e2657deb9f518607193c48673270fbb40e1ae70c022737f4fb1f10d697fc2e",
+    "zh:3e522fd06c0f8757510e39939d5b00dbc9c0712c9f25373ff89770501df5dd93",
+    "zh:4fe718731a615a78a38a9485d21817f3168a311338e3ae31f0de86c0f5a53c40",
+    "zh:64326e8fb391ac269361f0cabb929e842273781b082abba782d088f31e6a0250",
+    "zh:71b95eff24ed205c18f756acb4e8da6a60a9406267271ac40a5a41516e4ed376",
+    "zh:7e4db76bad642721b67cee2e13f4c52f4b38ac15ea3fbe7bbb267e15abf793ed",
+    "zh:a8251fdef80c407e7e63cf24a815b3b6d6a15c27618a379d0344c61aaf48b552",
+    "zh:bc37e63accc2d65fa37934c8dc56317ef39f1e269ef56603a94f74c7b4fd564d",
+    "zh:dbe4c17db018637d1e6ffd3c1090edd6a0ea89c2859e535b9a9ce99da0b054ab",
+    "zh:e52f3708c9c97b7113c61a00567fdb7de70a2ac870016fa6761d0794cc191900",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/TESTING.md
+++ b/terraform/TESTING.md
@@ -1,0 +1,285 @@
+# Terraform Testing Guide
+
+This document describes how to test the GCP Artifact Registry Terraform configuration.
+
+## Overview
+
+The Terraform configuration includes automated validation tests that verify:
+- Configuration syntax and format
+- Input variable validation (project_id, region, artifact_registry_writers)
+- Resource plan generation
+- IAM format validation
+
+## Prerequisites
+
+- Terraform >= 1.0 installed
+- GCP project ID: `marufeuille-linebot`
+- `gcloud auth application-default login` completed for authentication
+- jq (for plan JSON parsing)
+
+## Running Tests
+
+### Full Test Suite
+
+Run all validation tests:
+
+```bash
+cd terraform
+bash tests/terraform_validate_test.sh
+```
+
+This script will execute:
+1. Terraform format validation
+2. Terraform initialization
+3. Configuration validation
+4. Plan generation for dev environment
+5. Resource plan verification
+6. Input validation tests (invalid project_id, region, IAM format)
+
+### Individual Tests
+
+#### Test 1: Format Check
+
+```bash
+cd terraform
+terraform fmt -check -recursive .
+```
+
+To automatically fix formatting issues:
+```bash
+terraform fmt -recursive .
+```
+
+#### Test 2: Initialize Backend
+
+```bash
+cd terraform
+terraform init
+```
+
+This initializes the GCS backend at `marufeuille-linebot-terraform-backend`.
+
+#### Test 3: Validate Configuration
+
+```bash
+cd terraform
+terraform validate
+```
+
+Checks for syntax errors and configuration consistency.
+
+#### Test 4: Plan Resources
+
+```bash
+cd terraform
+terraform plan -var-file="environments/dev.tfvars" -out=tfplan
+```
+
+Or with custom values:
+```bash
+terraform plan \
+  -var="project_id=marufeuille-linebot" \
+  -var="region=asia-northeast1" \
+  -var='artifact_registry_writers=["serviceAccount:ci@marufeuille-linebot.iam.gserviceaccount.com"]'
+```
+
+#### Test 5: Show Plan Details
+
+```bash
+cd terraform
+terraform show tfplan
+```
+
+To view in JSON format:
+```bash
+terraform show tfplan -json | jq .
+```
+
+## Input Validation
+
+The configuration includes validation blocks that enforce input constraints:
+
+### project_id
+
+- **Format**: 6-30 characters, lowercase letters, digits, and hyphens
+- **Requirement**: Must start and end with lowercase letter or digit
+- **Example**: `marufeuille-linebot`
+
+Valid:
+```bash
+terraform plan -var="project_id=marufeuille-linebot" ...
+```
+
+Invalid:
+```bash
+# Too short
+terraform plan -var="project_id=proj" ...
+
+# Invalid characters (uppercase)
+terraform plan -var="project_id=MyProject" ...
+
+# Starts with hyphen
+terraform plan -var="project_id=-invalid" ...
+```
+
+### region
+
+- **Format**: Valid GCP region identifier
+- **Default**: `asia-northeast1`
+- **Examples**: `us-central1`, `europe-west1`, `asia-southeast2`
+
+Valid regions:
+```bash
+terraform plan -var="region=us-central1" ...
+terraform plan -var="region=europe-west1" ...
+```
+
+Invalid:
+```bash
+terraform plan -var="region=invalid-region" ...
+```
+
+### artifact_registry_writers
+
+- **Format**: List of IAM members in `type:identifier` format
+- **Valid types**: `serviceAccount`, `user`
+- **Default**: Empty list (no write permissions)
+
+Valid formats:
+```bash
+terraform plan -var='artifact_registry_writers=["serviceAccount:ci@marufeuille-linebot.iam.gserviceaccount.com"]' ...
+terraform plan -var='artifact_registry_writers=["user:developer@example.com","serviceAccount:bot@project.iam.gserviceaccount.com"]' ...
+```
+
+Invalid:
+```bash
+# Missing type prefix
+terraform plan -var='artifact_registry_writers=["ci@marufeuille-linebot.iam.gserviceaccount.com"]' ...
+
+# Invalid type
+terraform plan -var='artifact_registry_writers=["group:team@example.com"]' ...
+```
+
+## Expected Outputs
+
+### Successful terraform init
+
+```
+Initializing the backend...
+Successfully configured the backend "gcs"!
+...
+Terraform has been successfully initialized!
+```
+
+### Successful terraform validate
+
+```
+Success! The configuration is valid.
+```
+
+### Successful terraform plan
+
+```
+Terraform will perform the following actions:
+
+  # module.artifact_registry.google_artifact_registry_repository.repository will be created
+  + resource "google_artifact_registry_repository" "repository" {
+      + description               = "Docker container repository for dev environment"
+      + format                    = "DOCKER"
+      + id                        = (known after apply)
+      + location                  = "asia-northeast1"
+      + project                   = "marufeuille-linebot"
+      + repository_id             = "dev-containers"
+      ...
+    }
+
+  # module.artifact_registry.google_artifact_registry_repository_iam_member.writers[*] will be created
+  + resource "google_artifact_registry_repository_iam_member" "writers" {
+      + etag       = (known after apply)
+      + member     = "serviceAccount:ci@marufeuille-linebot.iam.gserviceaccount.com"
+      + project    = "marufeuille-linebot"
+      + repository = "dev-containers"
+      + role       = "roles/artifactregistry.writer"
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+```
+
+## Troubleshooting
+
+### Backend Initialization Failed
+
+If you encounter GCS bucket access errors:
+```
+Error acquiring the state lock: Error reading GCS object:
+```
+
+Verify:
+1. GCS bucket exists: `gsutil ls gs://marufeuille-linebot-terraform-backend`
+2. You have appropriate permissions: `gsutil iam ch user:$USER:objectViewer gs://marufeuille-linebot-terraform-backend`
+3. Authenticate: `gcloud auth application-default login`
+
+### Validation Errors
+
+If a variable validation fails, check the error message and fix the input:
+
+```bash
+# Example: Invalid project_id
+terraform plan -var="project_id=invalid!project"
+
+# Error:
+# Invalid or missing required argument: project_id must be 6-30 characters,
+# start and end with lowercase letters or digits, and contain only lowercase
+# letters, digits, and hyphens.
+```
+
+### Permission Errors
+
+If you encounter IAM permission errors during plan:
+```
+Error: Error creating Artifact Registry: googleapi: Error 403
+```
+
+Verify you have the required roles:
+- `roles/artifactregistry.admin` (to create repositories)
+- `roles/iam.securityAdmin` (to manage IAM bindings)
+
+## CI/CD Integration
+
+To run tests in a CI/CD pipeline:
+
+```yaml
+# Example: GitHub Actions
+- name: Terraform Format
+  run: terraform fmt -check -recursive terraform/
+
+- name: Run Terraform Tests
+  run: bash terraform/tests/terraform_validate_test.sh
+```
+
+## Adding New Tests
+
+To add a new validation test:
+
+1. Edit `terraform/tests/terraform_validate_test.sh`
+2. Add a new test function following the existing pattern
+3. Increment the TEST number in the output
+4. Run the full test suite to verify
+
+Example:
+```bash
+# Test N: Custom validation
+echo -e "${YELLOW}[TEST N]${NC} Testing new validation..."
+if terraform plan [OPTIONS] > /dev/null 2>&1; then
+  echo -e "${GREEN}✓${NC} Test passed"
+else
+  echo -e "${RED}✗${NC} Test failed"
+  exit 1
+fi
+```
+
+## References
+
+- [Terraform Validation Blocks](https://www.terraform.io/language/values/variables#custom-validation-rules)
+- [GCP Artifact Registry](https://cloud.google.com/artifact-registry/docs)
+- [Terraform GCP Provider](https://registry.terraform.io/providers/hashicorp/google/latest/docs)

--- a/terraform/environments/dev.tfvars
+++ b/terraform/environments/dev.tfvars
@@ -1,0 +1,9 @@
+project_id = "marufeuille-linebot"
+region     = "asia-northeast1"
+
+# IAM permissions for pushing images to Artifact Registry
+# Uncomment and add members (service accounts or users) to grant artifactregistry.writer role
+# Example formats:
+#   - "serviceAccount:my-sa@marufeuille-linebot.iam.gserviceaccount.com"
+#   - "user:your-email@example.com"
+# artifact_registry_writers = ["serviceAccount:ci-cd@marufeuille-linebot.iam.gserviceaccount.com"]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  backend "gcs" {
+    bucket = "marufeuille-linebot-terraform-backend"
+    prefix = "artifact-registry"
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+module "artifact_registry" {
+  source = "./modules/artifact_registry"
+
+  project_id      = var.project_id
+  region          = var.region
+  repository_name = "dev-containers"
+  description     = "Docker container repository for dev environment"
+
+  # IAM configuration for pushing images
+  # Example: ["serviceAccount:my-sa@project.iam.gserviceaccount.com", "user:user@example.com"]
+  artifact_registry_writers = var.artifact_registry_writers
+}

--- a/terraform/modules/artifact_registry/main.tf
+++ b/terraform/modules/artifact_registry/main.tf
@@ -1,0 +1,18 @@
+resource "google_artifact_registry_repository" "docker" {
+  location      = var.region
+  repository_id = var.repository_name
+  description   = var.description
+  format        = "DOCKER"
+  project       = var.project_id
+}
+
+# Grant artifactregistry.writer role to specified members for pushing images
+resource "google_artifact_registry_repository_iam_member" "writer" {
+  for_each = toset(var.artifact_registry_writers)
+
+  project    = var.project_id
+  location   = var.region
+  repository = google_artifact_registry_repository.docker.name
+  role       = "roles/artifactregistry.writer"
+  member     = each.value
+}

--- a/terraform/modules/artifact_registry/outputs.tf
+++ b/terraform/modules/artifact_registry/outputs.tf
@@ -1,0 +1,19 @@
+output "repository_url" {
+  description = "Repository URL for pushing Docker images"
+  value       = "${var.region}-docker.pkg.dev/${var.project_id}/${var.repository_name}"
+}
+
+output "repository_id" {
+  description = "Repository ID"
+  value       = "${var.project_id}/${var.region}/${var.repository_name}"
+}
+
+output "repository_name" {
+  description = "Repository Name"
+  value       = var.repository_name
+}
+
+output "artifact_registry_writers" {
+  description = "List of members with artifactregistry.writer role"
+  value       = var.artifact_registry_writers
+}

--- a/terraform/modules/artifact_registry/variables.tf
+++ b/terraform/modules/artifact_registry/variables.tf
@@ -1,0 +1,82 @@
+variable "project_id" {
+  description = "GCP Project ID"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]{4,28}[a-z0-9]$", var.project_id))
+    error_message = "Project ID must be 6-30 characters, start and end with lowercase letters or digits, and contain only lowercase letters, digits, and hyphens."
+  }
+}
+
+variable "region" {
+  description = "GCP Region"
+  type        = string
+
+  validation {
+    condition = contains([
+      "asia-east1",
+      "asia-east2",
+      "asia-northeast1",
+      "asia-northeast2",
+      "asia-northeast3",
+      "asia-south1",
+      "asia-south2",
+      "asia-southeast1",
+      "asia-southeast2",
+      "europe-central2",
+      "europe-north1",
+      "europe-southwest1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "europe-west6",
+      "europe-west8",
+      "europe-west9",
+      "europe-west12",
+      "me-central1",
+      "me-central2",
+      "me-west1",
+      "northamerica-northeast1",
+      "northamerica-northeast2",
+      "southamerica-east1",
+      "southamerica-west1",
+      "us-central1",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4"
+    ], var.region)
+    error_message = "Region must be a valid GCP region."
+  }
+}
+
+variable "repository_name" {
+  description = "Artifact Registry Repository Name"
+  type        = string
+  default     = "dev-containers"
+}
+
+variable "description" {
+  description = "Repository Description"
+  type        = string
+  default     = "Docker container repository for dev environment"
+}
+
+variable "artifact_registry_writers" {
+  description = "List of members (service accounts or users) with artifactregistry.writer role. Format: 'serviceAccount:EMAIL' or 'user:EMAIL'"
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for member in var.artifact_registry_writers :
+      can(regex("^(serviceAccount|user):.+$", member))
+    ])
+    error_message = "Each member must be in format 'serviceAccount:EMAIL' or 'user:EMAIL'. Example: 'serviceAccount:my-sa@project.iam.gserviceaccount.com'"
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,19 @@
+output "repository_url" {
+  description = "Artifact Registry Repository URL"
+  value       = module.artifact_registry.repository_url
+}
+
+output "repository_id" {
+  description = "Artifact Registry Repository ID"
+  value       = module.artifact_registry.repository_id
+}
+
+output "repository_name" {
+  description = "Artifact Registry Repository Name"
+  value       = module.artifact_registry.repository_name
+}
+
+output "artifact_registry_writers" {
+  description = "List of members with artifactregistry.writer role"
+  value       = module.artifact_registry.artifact_registry_writers
+}

--- a/terraform/tests/terraform_validate_test.sh
+++ b/terraform/tests/terraform_validate_test.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+#
+# Terraform Configuration Validation Tests
+# This script validates the Terraform configuration for GCP Artifact Registry
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "================================"
+echo "Terraform Configuration Tests"
+echo "================================"
+echo ""
+
+# Test 1: Terraform format validation
+echo -e "${YELLOW}[TEST 1]${NC} Checking Terraform format..."
+if terraform fmt -check -recursive . > /dev/null 2>&1; then
+  echo -e "${GREEN}✓${NC} Terraform format is valid"
+else
+  echo -e "${RED}✗${NC} Terraform format check failed"
+  echo "Run: terraform fmt -recursive . to fix formatting issues"
+  exit 1
+fi
+echo ""
+
+# Test 2: Terraform init
+echo -e "${YELLOW}[TEST 2]${NC} Initializing Terraform..."
+if terraform init -input=false > /dev/null 2>&1; then
+  echo -e "${GREEN}✓${NC} Terraform init succeeded"
+else
+  echo -e "${RED}✗${NC} Terraform init failed"
+  exit 1
+fi
+echo ""
+
+# Test 3: Terraform validate
+echo -e "${YELLOW}[TEST 3]${NC} Validating Terraform configuration..."
+if terraform validate > /dev/null 2>&1; then
+  echo -e "${GREEN}✓${NC} Terraform configuration is valid"
+else
+  echo -e "${RED}✗${NC} Terraform validation failed"
+  terraform validate
+  exit 1
+fi
+echo ""
+
+# Test 4: Terraform plan with dev environment
+echo -e "${YELLOW}[TEST 4]${NC} Running Terraform plan for dev environment..."
+if terraform plan -var-file="environments/dev.tfvars" -out=tfplan > /dev/null 2>&1; then
+  echo -e "${GREEN}✓${NC} Terraform plan succeeded"
+else
+  echo -e "${RED}✗${NC} Terraform plan failed"
+  terraform plan -var-file="environments/dev.tfvars"
+  exit 1
+fi
+echo ""
+
+# Test 5: Verify resource plan output
+echo -e "${YELLOW}[TEST 5]${NC} Verifying planned resources..."
+PLAN_OUTPUT=$(terraform show tfplan -json | jq -r '.resource_changes[]? | select(.type == "google_artifact_registry_repository") | .type' 2>/dev/null || echo "")
+
+if [ -n "$PLAN_OUTPUT" ]; then
+  echo -e "${GREEN}✓${NC} google_artifact_registry_repository resource found in plan"
+else
+  echo -e "${YELLOW}!${NC} Warning: google_artifact_registry_repository not found in plan (may be expected if resource already exists)"
+fi
+echo ""
+
+# Test 6: Validate input variables with bad values
+echo -e "${YELLOW}[TEST 6]${NC} Testing input validation (invalid project_id)..."
+if terraform plan -var="project_id=invalid_project_id" -var-file="environments/dev.tfvars" > /dev/null 2>&1; then
+  echo -e "${RED}✗${NC} Validation should have failed for invalid project_id"
+  exit 1
+else
+  echo -e "${GREEN}✓${NC} Correctly rejected invalid project_id"
+fi
+echo ""
+
+# Test 7: Validate input variables with bad region
+echo -e "${YELLOW}[TEST 7]${NC} Testing input validation (invalid region)..."
+if terraform plan -var="region=invalid-region" -var-file="environments/dev.tfvars" > /dev/null 2>&1; then
+  echo -e "${RED}✗${NC} Validation should have failed for invalid region"
+  exit 1
+else
+  echo -e "${GREEN}✓${NC} Correctly rejected invalid region"
+fi
+echo ""
+
+# Test 8: Validate IAM format
+echo -e "${YELLOW}[TEST 8]${NC} Testing input validation (invalid IAM format)..."
+if terraform plan -var-file="environments/dev.tfvars" -var='artifact_registry_writers=["invalid-format"]' > /dev/null 2>&1; then
+  echo -e "${RED}✗${NC} Validation should have failed for invalid IAM format"
+  exit 1
+else
+  echo -e "${GREEN}✓${NC} Correctly rejected invalid IAM format"
+fi
+echo ""
+
+# Test 9: Validate valid IAM formats
+echo -e "${YELLOW}[TEST 9]${NC} Testing input validation (valid IAM formats)..."
+if terraform plan -var-file="environments/dev.tfvars" -var='artifact_registry_writers=["serviceAccount:test@project.iam.gserviceaccount.com","user:test@example.com"]' > /dev/null 2>&1; then
+  echo -e "${GREEN}✓${NC} Correctly accepted valid IAM formats"
+else
+  echo -e "${RED}✗${NC} Validation failed for valid IAM formats"
+  terraform plan -var-file="environments/dev.tfvars" -var='artifact_registry_writers=["serviceAccount:test@project.iam.gserviceaccount.com","user:test@example.com"]'
+  exit 1
+fi
+echo ""
+
+# Cleanup
+rm -f tfplan
+
+echo "================================"
+echo -e "${GREEN}All tests passed!${NC}"
+echo "================================"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,71 @@
+variable "project_id" {
+  description = "GCP Project ID"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]{4,28}[a-z0-9]$", var.project_id))
+    error_message = "Project ID must be 6-30 characters, start and end with lowercase letters or digits, and contain only lowercase letters, digits, and hyphens."
+  }
+}
+
+variable "region" {
+  description = "GCP Region"
+  type        = string
+  default     = "asia-northeast1"
+
+  validation {
+    condition = contains([
+      "asia-east1",
+      "asia-east2",
+      "asia-northeast1",
+      "asia-northeast2",
+      "asia-northeast3",
+      "asia-south1",
+      "asia-south2",
+      "asia-southeast1",
+      "asia-southeast2",
+      "europe-central2",
+      "europe-north1",
+      "europe-southwest1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "europe-west6",
+      "europe-west8",
+      "europe-west9",
+      "europe-west12",
+      "me-central1",
+      "me-central2",
+      "me-west1",
+      "northamerica-northeast1",
+      "northamerica-northeast2",
+      "southamerica-east1",
+      "southamerica-west1",
+      "us-central1",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4"
+    ], var.region)
+    error_message = "Region must be a valid GCP region."
+  }
+}
+
+variable "artifact_registry_writers" {
+  description = "List of members (service accounts or users) with artifactregistry.writer role for pushing images. Format: 'serviceAccount:EMAIL' or 'user:EMAIL'"
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for member in var.artifact_registry_writers :
+      can(regex("^(serviceAccount|user):.+$", member))
+    ])
+    error_message = "Each member must be in format 'serviceAccount:EMAIL' or 'user:EMAIL'. Example: 'serviceAccount:my-sa@project.iam.gserviceaccount.com'"
+  }
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/test_terraform_config.sh
+++ b/test_terraform_config.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -e
+PASS=0
+FAIL=0
+
+test_case() {
+  local name="$1"
+  local condition="$2"
+  if eval "$condition"; then
+    echo "✓ $name"
+    ((PASS++))
+  else
+    echo "✗ $name"
+    ((FAIL++))
+  fi
+}
+
+echo "=== Terraform Configuration Tests ==="
+echo ""
+
+# Test backend configuration
+test_case "GCS backend bucket correct" "grep -q 'marufeuille-linebot-terraform-backend' terraform/main.tf"
+test_case "Backend prefix set" "grep -q 'artifact-registry' terraform/main.tf"
+
+# Test provider configuration
+test_case "Google provider configured" "grep -q 'provider \"google\"' terraform/main.tf"
+test_case "Project ID uses variable" "grep -q 'project = var.project_id' terraform/main.tf"
+test_case "Region uses variable" "grep -q 'region = var.region' terraform/main.tf"
+
+# Test variables
+test_case "Project ID variable exists" "grep -q 'variable \"project_id\"' terraform/variables.tf"
+test_case "Region variable exists" "grep -q 'variable \"region\"' terraform/variables.tf"
+test_case "Region default is asia-northeast1" "grep -q 'asia-northeast1' terraform/variables.tf"
+
+# Test outputs
+test_case "Repository URL output exists" "grep -q 'repository_url' terraform/outputs.tf"
+test_case "Repository ID output exists" "grep -q 'repository_id' terraform/outputs.tf"
+test_case "Repository name output exists" "grep -q 'repository_name' terraform/outputs.tf"
+
+# Test module
+test_case "Module path is relative" "grep -q './modules/artifact_registry' terraform/main.tf"
+test_case "Module repository name is dev-containers" "grep -q 'dev-containers' terraform/main.tf"
+test_case "AR resource format is DOCKER" "grep -q 'DOCKER' terraform/modules/artifact_registry/main.tf"
+
+# Test module variables
+test_case "Module project_id variable" "grep -q 'variable \"project_id\"' terraform/modules/artifact_registry/variables.tf"
+test_case "Module region variable" "grep -q 'variable \"region\"' terraform/modules/artifact_registry/variables.tf"
+test_case "Module repository_name variable" "grep -q 'variable \"repository_name\"' terraform/modules/artifact_registry/variables.tf"
+
+# Test environment variables
+test_case "dev.tfvars has project_id" "grep -q 'marufeuille-linebot' terraform/environments/dev.tfvars"
+test_case "dev.tfvars has region" "grep -q 'asia-northeast1' terraform/environments/dev.tfvars"
+
+# Test version constraints
+test_case "Terraform >= 1.0" "grep -q '>= 1.0' terraform/versions.tf"
+test_case "Google provider >= 5.0" "grep -q '>= 5.0' terraform/versions.tf"
+
+echo ""
+echo "=== Test Summary ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ $FAIL -eq 0 ]; then
+  echo "All tests passed! ✓"
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
## タスク概要

GCP上のArtifact Registryを作成し、コンテナイメージをpushできるようにTerraformで管理する。モジュール構成を採用し、dev環境用の初期実装を行う。GCPプロジェクトIDはハードコードせず、変数から入力可能にする。認証は `gcloud auth` を前提とする。

## 要件

| 要件 | 詳細 |
|------|------|
| Artifact Registry 作成 | dev環境用のコンテナリポジトリを作成 |
| Terraform モジュール構成 | 再利用可能なモジュール設計 |
| 変数化 | GCPプロジェクトID（`marufeuille-linebot`）をハードコード厳禁 | | バックエンド | GCS: `marufeuille-linebot-terraform-backend` | | ディレクトリ構成 | プロジェクト直下に `terraform/` ディレクトリ |
| コンテナイメージpush対応 | 認証・権限設定を含める |
| 認証方式 | `gcloud auth` で認証済みの状態を前提 |

## 対象ファイル・モジュール

| 種別 | パス | 説明 |
|------|------|------|
| 作成 | `terraform/` | ルートディレクトリ |
| 作成 | `terraform/main.tf` | バックエンド・プロバイダ設定 |
| 作成 | `terraform/variables.tf` | 入力変数（プロジェクトID等） | | 作成 | `terraform/outputs.tf` | 出力値 |
| 作成 | `terraform/versions.tf` | Terraform/プロバイダバージョン定義 | | 作成 | `terraform/modules/artifact_registry/` | Artifact Registry モジュール | | 作成 | `terraform/modules/artifact_registry/main.tf` | AR リソース定義 | | 作成 | `terraform/modules/artifact_registry/variables.tf` | モジュール入力変数 | | 作成 | `terraform/modules/artifact_registry/outputs.tf` | モジュール出力値 | | 作成 | `terraform/environments/dev.tfvars` | dev環境変数 |

## 作業内容（優先度順）

### 高優先度

#### 1. Terraform ファイル構造の設計・実装

**`terraform/versions.tf`:**
- Terraform バージョン制約を指定（推奨: >= 1.0）
- Google プロバイダバージョン制約（推奨: >= 5.0）

**`terraform/main.tf`:**
- バックエンド設定（GCS: `marufeuille-linebot-terraform-backend`）
- Google プロバイダの設定
  - 認証: `gcloud auth` により認証済みの状態を想定（Credentialsは明示的に指定しない）
  - プロジェクトID: 変数から参照
  - リージョン: デフォルト値を `asia-northeast1` に設定（変数化）
- モジュール呼び出し: `artifact_registry` モジュール

**`terraform/variables.tf`:**
- `project_id`: GCPプロジェクトID（ハードコード厳禁、必須変数）
- `region`: GCP リージョン（デフォルト: `asia-northeast1`）

**`terraform/outputs.tf`:**
- Artifact Registry のリポジトリURL
- リポジトリID
- リポジトリ名

**`terraform/environments/dev.tfvars`:**
- `project_id = "marufeuille-linebot"`
- `region = "asia-northeast1"` など環境固有値

#### 2. Artifact Registry モジュールの実装

**`terraform/modules/artifact_registry/main.tf`:**
- `google_artifact_registry_repository` リソース定義
  - 形式: Docker
  - リポジトリ名: 変数から参照（例: dev環境の場合 `dev-containers`）
  - 説明文: 変数から参照
  - ロケーション: 変数から参照
  - プロジェクトID: 親モジュールから受け取る

**`terraform/modules/artifact_registry/variables.tf`:**
- `project_id`: GCPプロジェクトID
- `region`: GCP リージョン
- `repository_name`: リポジトリ名（デフォルト: `dev-containers`）
- `description`: リポジトリ説明（デフォルト: `Docker container repository for dev environment`）

**`terraform/modules/artifact_registry/outputs.tf`:**
- `repository_url`: リポジトリURL（`{region}-docker.pkg.dev/{project_id}/{repository_name}` 形式）
- `repository_id`: リポジトリID（`{project_id}/{region}/{repository_name}` 形式）
- `repository_name`: リポジトリ名

#### 3. ルートモジュールでのモジュール呼び出し

**`terraform/main.tf` のモジュールセクション:**
```
module "artifact_registry" {
  source = "./modules/artifact_registry"

  project_id      = var.project_id
  region          = var.region
  repository_name = "dev-containers"
  description     = "Docker container repository for dev environment"
}
```

### 中優先度

#### 4. 実行可能な初期状態の確認

- `terraform init` でバックエンド初期化が成功すること
- `terraform validate` で構文検証が成功すること
- `terraform plan -var-file="environments/dev.tfvars"` でplan成功、期待されるリソース作成計画が出力されること
- エラーなし、警告は許容（後続タスクで対応可）

## 制約・注意事項

| 項目 | 内容 |
|------|------|
| プロジェクトID | ハードコード厳禁。変数から入力必須 |
| バックエンド | `marufeuille-linebot-terraform-backend` GCSバケット使用 | | 環境 | 初期は dev のみ（stagingやprodは後続タスク） |
| 認証 | `gcloud auth application-default login` で認証済みの状態を前提。Credentialsファイル参照は不要 | | リージョン | 変数化必須（ハードコード回避） |

## 確認方法

1. **ファイル構成確認**: ``` terraform/ ├── main.tf ├── variables.tf ├── outputs.tf ├── versions.tf ├── environments/
   │   └── dev.tfvars
   └── modules/
       └── artifact_registry/
           ├── main.tf
           ├── variables.tf
           └── outputs.tf
   ```

2. **動作確認**: ```bash cd terraform terraform init terraform validate terraform plan -var-file="environments/dev.tfvars" ```
   - 全コマンドがエラーなしで完了すること
   - plan出力で `google_artifact_registry_repository` リソースの作成が計画されていること