### PR TITLE
takt: ## タスク指示書：GitHub Actions CI（Python）の実装

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Lint
+        run: uv run ruff check .
+
+      - name: Format check
+        run: uv run ruff format --check .
+
+      - name: Type check
+        # [tool.mypy] が未定義のため --ignore-missing-imports を明示
+        run: uv run mypy v2 main_v2.py --ignore-missing-imports
+
+      - name: Test
+        # manual マーカーは実際の API 呼び出しを行うため CI では除外
+        run: uv run pytest -m "not manual" --cov --cov-report=html --cov-report=xml
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            htmlcov/
+            coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,10 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "mypy>=1.0.0",
     "pytest>=8.0.0",
     "pytest-cov>=4.1.0",
+    "ruff>=0.9.0",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
### 概要

`.github/workflows/ci.yml` を新規作成し、Python プロジェクトの CI ワークフローを実装する。

---

### 作業内容

#### `.github/workflows/ci.yml`（新規作成）【優先度：高】

**事前調査（実装前に `pyproject.toml` を読んで確認）:**
- `requires-python` 等の Python バージョン指定
- `[tool.mypy]` セクションの有無
- テストディレクトリ構成（`tests/` 等）

**トリガー:**
- `push`、`pull_request`（対象ブランチ: `main`）

**セットアップ:**
- `actions/checkout` でリポジトリをチェックアウト
- `astral-sh/setup-uv` 等で `uv` をセットアップ
- `pyproject.toml` の `requires-python` から Python バージョンを読み取り、`actions/setup-python` で指定
- `uv sync` で依存関係をインストール

**ステップ構成:**

1. **Lint / Format チェック** ``` uv run ruff check . uv run ruff format --check . ```

2. **型チェック**
   - `pyproject.toml` に `[tool.mypy]` があれば: `uv run mypy`
   - `[tool.mypy]` がなければ: `uv run mypy --ignore-missing-imports`

3. **テスト + カバレッジ計測** ``` uv run pytest --cov --cov-report=html --cov-report=xml ```
   - `actions/upload-artifact` で HTML・XML レポートをアップロード（artifact 名: `coverage-report`）

**ジョブ構成:**
- プロジェクト構成（依存関係・テスト規模）を確認した上で、1ジョブにまとめるか分割するか判断する

---

### やらないこと

- Codecov 等の外部サービスへのレポート送信
- 複数 Python バージョンのマトリックスビルド
- mypy の `--strict` モード使用