### PR TITLE
ci: v2/ Python向けGitHub Actions CI（ruff + pytest）を導入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "v2/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/ci.yml"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Ruff lint
+        run: uv run ruff check v2/
+
+      - name: Ruff format check
+        run: uv run ruff format --check v2/
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run tests
+        run: >
+          uv run pytest
+          tests/unit/
+          tests/integration/
+          -m "not manual"
+          --cov=v2
+          --cov-report=term-missing

--- a/docs/plan/ci-python-v2.md
+++ b/docs/plan/ci-python-v2.md
@@ -1,0 +1,186 @@
+# CI設計：v2/ Python コード向け GitHub Actions
+
+## Context
+
+`v2/` 配下のPythonコードに対するCI（継続的インテグレーション）が未導入の状態。
+以前存在していたワークフロー（commit `eb5ad70`で削除済み）を踏まえ、ruff（linter/formatter）と pytest によるCIを GitHub Actions で新規構築する。
+
+---
+
+## 方針サマリ
+
+| 項目 | 内容 |
+|------|------|
+| CIプラットフォーム | GitHub Actions |
+| トリガー | Pull Request to `main` のみ |
+| パスフィルター | `v2/**`, `tests/**`, `pyproject.toml`, `uv.lock`, `.github/workflows/ci.yml` |
+| Linter | ruff (lint + format check) |
+| テスト | pytest (`tests/unit/`, `tests/integration/` のうち `-m "not manual"`) |
+| パッケージ管理 | uv（既存のプロジェクト構成を踏襲） |
+| Python バージョン | 3.13 |
+
+---
+
+## 変更対象ファイル
+
+| ファイル | 操作 | 目的 |
+|----------|------|------|
+| `.github/workflows/ci.yml` | **新規作成** | CIワークフロー定義 |
+| `pyproject.toml` | **編集** | `[tool.ruff]` セクション追加 |
+
+---
+
+## 1. pyproject.toml への ruff 設定追加
+
+既存の `[tool.pytest.ini_options]` セクションの後に以下を追加する。
+
+```toml
+[tool.ruff]
+target-version = "py313"
+src = ["v2", "tests"]
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort (import ordering)
+    "UP",   # pyupgrade (Python 3.13向けモダン化)
+    "B",    # flake8-bugbear (よくあるバグパターン)
+    "SIM",  # flake8-simplify
+]
+```
+
+### 設定の根拠
+
+- `target-version = "py313"` — Python 3.13を前提としたルール適用
+- `src = ["v2", "tests"]` — isortがファーストパーティimportを正しく識別するためのソースルート指定
+- `select` は保守的なルールセット。`D`（docstring）や `ANN`（型アノテーション）など、既存コードに大量の警告を出すルールは含めない
+- `[tool.ruff.format]` は不要（デフォルトの88文字/ダブルクォートで問題ない）
+
+---
+
+## 2. GitHub Actions ワークフロー
+
+### 2.1 ジョブ構成
+
+**lint** と **test** の2ジョブに分離し、並列実行する。
+
+- lint は高速（数秒）に完了するため、テスト完了を待たずフォーマット/lint違反を即座にフィードバックできる
+- 失敗のセマンティクスが異なる（スタイル違反 vs ロジック不具合）
+
+### 2.2 ワークフロー定義 (`.github/workflows/ci.yml`)
+
+```yaml
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "v2/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/ci.yml"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Ruff lint
+        run: uv run ruff check v2/ tests/
+
+      - name: Ruff format check
+        run: uv run ruff format --check v2/ tests/
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run tests
+        run: >
+          uv run pytest
+          tests/unit/
+          tests/integration/
+          -m "not manual"
+          --cov=v2
+          --cov-report=term-missing
+
+```
+
+### 2.3 設計判断
+
+| 判断 | 理由 |
+|------|------|
+| PR のみトリガー | push + PR だと同一コミットで二重実行されるため |
+| パスフィルター導入 | ドキュメントのみの変更でCI消費を防ぐ |
+| `astral-sh/setup-uv@v5` + `enable-cache: true` | uv のパッケージキャッシュを自動管理。追加の `actions/cache` 不要 |
+| テスト対象: `tests/unit/` + `tests/integration/` | `tests/e2e/` はpytestテスト形式でなくスクリプト形式のため除外。`tests/manual/` は実API依存のため除外 |
+| `-m "not manual"` | `tests/integration/test_adapters_manual.py` の全テストが `@pytest.mark.manual` 付きのため安全に除外 |
+| `--cov=v2` | カバレッジ計測対象を `v2/` プロダクションコードに限定 |
+| `--cov-report=term-missing` | CIログ上でカバレッジと未カバー行を確認可能 |
+| mypy は含めない | 今回のスコープ外（ruff + pytest のみ） |
+
+---
+
+## 3. 注意事項
+
+### 既存コードの ruff 違反
+
+ruff を新規導入するため、初回実行時に `v2/` や `tests/` で既存のlint/format違反が検出される可能性が高い。CI導入PRの一部として以下を事前に実行し修正すること。
+
+```bash
+uv run ruff check --fix v2/ tests/
+uv run ruff format v2/ tests/
+```
+
+### integration テストの安全性
+
+`tests/integration/test_adapters_manual.py` 内の全テストクラスには `@pytest.mark.manual` が付与済みであることを確認済み。`-m "not manual"` により CI では安全にスキップされる。
+
+---
+
+## 4. 検証手順
+
+CI導入後、以下の手順で動作を検証する。
+
+1. **ローカルでの事前確認**
+   ```bash
+   uv run ruff check v2/ tests/
+   uv run ruff format --check v2/ tests/
+   uv run pytest tests/unit/ tests/integration/ -m "not manual" --cov=v2 --cov-report=term-missing
+   ```
+
+2. **PR作成による CI 動作確認**
+   - 新規ブランチで `.github/workflows/ci.yml` と `pyproject.toml` の変更をcommit
+   - main 向けにPRを作成し、lint / test の両ジョブが正常に完了することを確認
+
+3. **意図的な失敗テスト**（任意）
+   - ruff 違反を含むコードをpushし、lint ジョブが失敗することを確認
+   - 失敗するテストを追加し、test ジョブが失敗することを確認

--- a/docs/plan/container-deploy-artifact-registry.md
+++ b/docs/plan/container-deploy-artifact-registry.md
@@ -1,0 +1,359 @@
+# コンテナベースデプロイ導入：Artifact Registry + build/push スクリプト
+
+## Context
+
+現状の `deploy_v2.sh` は `gcloud functions deploy --gen2 --runtime=python313 --source=.` によるソースベースデプロイを採用している。Cloud Build が内部でコンテナを生成するため、ビルド過程の制御や再現性に課題がある。
+
+今後のCI/CD化・インフラのIaC化、およびdev/prod環境分離を見据え、以下を今回のスコープとして実装する：
+
+1. **Artifact Registry** を Terraform module 構成で管理（dev 環境を先行実装）
+2. **`build_push.sh`** — コンテナの build & Artifact Registry push を行うスクリプト
+
+Cloud Function 本体のデプロイ方式変更（`--image` フラグへの移行）は別タスクとする。
+
+---
+
+## 現状のファイル構成
+
+| ファイル | 役割 |
+|----------|------|
+| `Dockerfile` | 既存。python:3.13-slim ベース、functions-framework 起動 |
+| `.dockerignore` | 既存。.git, tests/, docs/ 等を除外 |
+| `deploy_v2.sh` | 既存のソースベースデプロイスクリプト（今回は変更しない） |
+| `requirements.txt` | `uv export` で生成。Dockerfile の `COPY requirements.txt .` で使用 |
+
+---
+
+## 変更・追加対象ファイル
+
+| ファイル | 操作 | 目的 |
+|----------|------|------|
+| `terraform/modules/artifact_registry/main.tf` | **新規作成** | Artifact Registry リソース定義（再利用可能なmodule） |
+| `terraform/modules/artifact_registry/variables.tf` | **新規作成** | module の入力変数 |
+| `terraform/modules/artifact_registry/outputs.tf` | **新規作成** | module の出力値 |
+| `terraform/environments/dev/main.tf` | **新規作成** | dev 環境のエントリポイント。provider定義とmodule呼び出し |
+| `terraform/environments/dev/variables.tf` | **新規作成** | dev 環境の変数定義 |
+| `terraform/environments/dev/outputs.tf` | **新規作成** | dev 環境の出力値 |
+| `build_push.sh` | **新規作成** | コンテナ build & push スクリプト |
+
+---
+
+## 1. Terraform 構成
+
+### 1.1 全体ディレクトリ構造
+
+```
+terraform/
+  modules/
+    artifact_registry/    # 再利用可能なmodule（環境を知らない）
+      main.tf
+      variables.tf
+      outputs.tf
+  environments/
+    dev/                  # dev 環境（今回実装）
+      main.tf
+      variables.tf
+      outputs.tf
+      terraform.tfvars    # ★ gitignore 対象（project_idを含む）
+    prod/                 # prod 環境（将来実装）
+      ...
+```
+
+**設計原則**：
+- `modules/` は環境に依存しない純粋なリソース定義。環境の数に関わらず1つだけ存在する
+- `environments/` は環境ごとに独立した `terraform init` / `state` を持つ
+- dev/prod は GCPプロジェクトを分けることを想定（同一プロジェクトの場合は `repository_id` の命名で区別）
+
+---
+
+### 1.2 `terraform/modules/artifact_registry/variables.tf`
+
+```hcl
+variable "project_id" {
+  description = "GCP プロジェクトID"
+  type        = string
+}
+
+variable "region" {
+  description = "Artifact Registry のロケーション"
+  type        = string
+}
+
+variable "repository_id" {
+  description = "Artifact Registry リポジトリID"
+  type        = string
+}
+
+variable "environment" {
+  description = "環境名（ラベル用）"
+  type        = string
+}
+```
+
+### 1.3 `terraform/modules/artifact_registry/main.tf`
+
+```hcl
+resource "google_artifact_registry_repository" "this" {
+  project       = var.project_id
+  location      = var.region
+  repository_id = var.repository_id
+  format        = "DOCKER"
+  description   = "school-agent コンテナイメージリポジトリ (${var.environment})"
+
+  labels = {
+    environment = var.environment
+    managed_by  = "terraform"
+  }
+}
+```
+
+### 1.4 `terraform/modules/artifact_registry/outputs.tf`
+
+```hcl
+output "registry_url" {
+  description = "Artifact Registry の Docker リポジトリ URL"
+  value       = "${var.region}-docker.pkg.dev/${var.project_id}/${var.repository_id}"
+}
+
+output "image_base" {
+  description = "イメージ名のベース（タグなし）"
+  value       = "${var.region}-docker.pkg.dev/${var.project_id}/${var.repository_id}/school-agent-v2"
+}
+```
+
+---
+
+### 1.5 `terraform/environments/dev/variables.tf`
+
+```hcl
+variable "project_id" {
+  description = "dev 環境の GCP プロジェクトID"
+  type        = string
+}
+
+variable "region" {
+  description = "デプロイリージョン"
+  type        = string
+  default     = "asia-northeast1"
+}
+```
+
+### 1.6 `terraform/environments/dev/main.tf`
+
+```hcl
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+  # 将来的にGCSバックエンドへ移行する（別タスク）
+  # backend "gcs" {
+  #   bucket = "YOUR_TFSTATE_BUCKET"
+  #   prefix = "terraform/environments/dev"
+  # }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+module "artifact_registry" {
+  source = "../../modules/artifact_registry"
+
+  project_id    = var.project_id
+  region        = var.region
+  repository_id = "school-agent-dev"
+  environment   = "dev"
+}
+```
+
+### 1.7 `terraform/environments/dev/outputs.tf`
+
+```hcl
+output "registry_url" {
+  description = "dev 環境の Artifact Registry URL"
+  value       = module.artifact_registry.registry_url
+}
+
+output "image_base" {
+  description = "dev 環境のイメージ名ベース"
+  value       = module.artifact_registry.image_base
+}
+```
+
+---
+
+## 2. build_push.sh
+
+### 2.1 責務
+
+1. 環境名（`dev` / `prod`）を引数またはデフォルト値で受け取る
+2. `.env` から `PROJECT_ID` を読み込む
+3. `uv export` で `requirements.txt` を生成（Dockerfile が `COPY requirements.txt .` で使用するため）
+4. イメージタグを決定（デフォルトは `git rev-parse --short HEAD`）
+5. `docker build` でコンテナをビルド
+6. `gcloud auth configure-docker` で Artifact Registry の認証設定
+7. `docker push` でイメージをプッシュ
+8. イメージURLを標準出力に出力（後続スクリプトや CI での利用を想定）
+
+### 2.2 スクリプト仕様
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# ==========================================
+# Configuration
+# ==========================================
+REGION="asia-northeast1"
+IMAGE_NAME="school-agent-v2"
+
+# 引数: ENV（dev/prod）, IMAGE_TAG（任意）
+ENV="${1:-dev}"
+IMAGE_TAG="${2:-$(git rev-parse --short HEAD 2>/dev/null || echo 'latest')}"
+
+# 環境ごとのリポジトリID
+case "$ENV" in
+  dev)  REPOSITORY_ID="school-agent-dev" ;;
+  prod) REPOSITORY_ID="school-agent" ;;
+  *)    echo "Error: Unknown environment '$ENV'. Use 'dev' or 'prod'."; exit 1 ;;
+esac
+
+# Load environment variables
+if [ -f .env ]; then
+  export $(cat .env | grep -v '#' | awk '/=/ {print $1}')
+fi
+
+# Check required
+if [ -z "${PROJECT_ID:-}" ]; then
+  echo "Error: PROJECT_ID is not set in .env"
+  exit 1
+fi
+
+IMAGE_URL="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPOSITORY_ID}/${IMAGE_NAME}:${IMAGE_TAG}"
+
+echo "Environment : ${ENV}"
+echo "Image URL   : ${IMAGE_URL}"
+
+# ==========================================
+# Preparation
+# ==========================================
+echo "Generating requirements.txt..."
+uv export -o requirements.txt --no-hashes
+
+# ==========================================
+# Build
+# ==========================================
+echo "Building Docker image..."
+docker build -t "${IMAGE_URL}" .
+
+# ==========================================
+# Push
+# ==========================================
+echo "Configuring Docker auth for Artifact Registry..."
+gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+
+echo "Pushing image..."
+docker push "${IMAGE_URL}"
+
+echo ""
+echo "Successfully pushed: ${IMAGE_URL}"
+# 後続の処理から参照できるようにexportで出力
+echo "IMAGE_URL=${IMAGE_URL}"
+```
+
+### 2.3 実行方法
+
+```bash
+# dev 環境へ push（git SHA タグ）
+./build_push.sh dev
+
+# dev 環境へ push（タグ明示指定）
+./build_push.sh dev v1.0.0
+
+# prod 環境へ push（将来）
+./build_push.sh prod v1.0.0
+```
+
+---
+
+## 3. Terraform 運用手順
+
+### 初回セットアップ（dev）
+
+```bash
+cd terraform/environments/dev
+
+# terraform.tfvars を作成（gitignore 対象）
+cat > terraform.tfvars <<EOF
+project_id = "YOUR_DEV_PROJECT_ID"
+EOF
+
+terraform init
+terraform plan
+terraform apply
+```
+
+### `.gitignore` に追加すべき項目
+
+```
+# Terraform
+terraform/**/.terraform/
+terraform/**/terraform.tfstate
+terraform/**/terraform.tfstate.backup
+terraform/**/terraform.tfvars
+```
+
+`**` を使うことで environments/dev と将来追加される environments/prod の両方に適用される。
+`terraform.tfvars` は `project_id` を含むため gitignore 対象。各 `variables.tf` はデフォルト値のみ持つため commit 可。
+
+---
+
+## 4. 今後の移行ロードマップ
+
+| フェーズ | 内容 |
+|----------|------|
+| **今回** | `terraform/modules/artifact_registry/` + `terraform/environments/dev/` + `build_push.sh` |
+| 次回 | `deploy_v2.sh` を `--image` ベースに変更し、コンテナデプロイを実現 |
+| 将来 | `terraform/environments/prod/` を追加し、prod 環境の Artifact Registry を構築 |
+| 将来 | Cloud Function・Scheduler・Secret Manager を Terraform module 化して各 environment から呼び出す |
+| 将来 | GCS バックエンドで Terraform State を管理 |
+| 将来 | GitHub Actions で build/push + deploy を自動化 |
+
+---
+
+## 5. 検証手順
+
+### Terraform の検証
+
+```bash
+cd terraform/environments/dev
+terraform init
+terraform validate        # 構文チェック
+terraform plan            # 差分確認（apply は実施しない）
+```
+
+### build_push.sh の検証
+
+```bash
+# ビルドのみ（push しない）
+uv export -o requirements.txt --no-hashes
+docker build -t school-agent-v2:test .
+docker run --rm school-agent-v2:test echo "startup ok"
+
+# dev 環境へ push（PROJECT_ID が設定済みの場合）
+./build_push.sh dev
+```
+
+### Artifact Registry への push 後確認
+
+```bash
+REGION="asia-northeast1"
+gcloud artifacts docker images list \
+  "${REGION}-docker.pkg.dev/${PROJECT_ID}/school-agent-dev" \
+  --project="${PROJECT_ID}"
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,21 @@ addopts = [
 markers = [
     "manual: 手動実行のみ（実際のAPI呼び出しを行う）",
 ]
+
+[tool.ruff]
+target-version = "py313"
+src = ["v2", "tests"]
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort (import ordering)
+    "UP",   # pyupgrade (Python 3.13向けモダン化)
+    "B",    # flake8-bugbear (よくあるバグパターン)
+    "SIM",  # flake8-simplify
+]
+ignore = [
+    "E501", # 行長はformatterが管理するため、linterでは除外
+]

--- a/uv.lock
+++ b/uv.lock
@@ -653,6 +653,53 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/9c/b4b0c54d84da4a94b37bd44151e46d5e583c9534c7e02250b961b1b6d8a8/librt-0.8.1.tar.gz", hash = "sha256:be46a14693955b3bd96014ccbdb8339ee8c9346fbe11c1b78901b55125f14c73", size = 177471 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/3c/f614c8e4eaac7cbf2bbdf9528790b21d89e277ee20d57dc6e559c626105f/librt-0.8.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7e6bad1cd94f6764e1e21950542f818a09316645337fd5ab9a7acc45d99a8f35", size = 66529 },
+    { url = "https://files.pythonhosted.org/packages/ab/96/5836544a45100ae411eda07d29e3d99448e5258b6e9c8059deb92945f5c2/librt-0.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cf450f498c30af55551ba4f66b9123b7185362ec8b625a773b3d39aa1a717583", size = 68669 },
+    { url = "https://files.pythonhosted.org/packages/06/53/f0b992b57af6d5531bf4677d75c44f095f2366a1741fb695ee462ae04b05/librt-0.8.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:eca45e982fa074090057132e30585a7e8674e9e885d402eae85633e9f449ce6c", size = 199279 },
+    { url = "https://files.pythonhosted.org/packages/f3/ad/4848cc16e268d14280d8168aee4f31cea92bbd2b79ce33d3e166f2b4e4fc/librt-0.8.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c3811485fccfda840861905b8c70bba5ec094e02825598bb9d4ca3936857a04", size = 210288 },
+    { url = "https://files.pythonhosted.org/packages/52/05/27fdc2e95de26273d83b96742d8d3b7345f2ea2bdbd2405cc504644f2096/librt-0.8.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e4af413908f77294605e28cfd98063f54b2c790561383971d2f52d113d9c363", size = 224809 },
+    { url = "https://files.pythonhosted.org/packages/7a/d0/78200a45ba3240cb042bc597d6f2accba9193a2c57d0356268cbbe2d0925/librt-0.8.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5212a5bd7fae98dae95710032902edcd2ec4dc994e883294f75c857b83f9aba0", size = 218075 },
+    { url = "https://files.pythonhosted.org/packages/af/72/a210839fa74c90474897124c064ffca07f8d4b347b6574d309686aae7ca6/librt-0.8.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e692aa2d1d604e6ca12d35e51fdc36f4cda6345e28e36374579f7ef3611b3012", size = 225486 },
+    { url = "https://files.pythonhosted.org/packages/a3/c1/a03cc63722339ddbf087485f253493e2b013039f5b707e8e6016141130fa/librt-0.8.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4be2a5c926b9770c9e08e717f05737a269b9d0ebc5d2f0060f0fe3fe9ce47acb", size = 218219 },
+    { url = "https://files.pythonhosted.org/packages/58/f5/fff6108af0acf941c6f274a946aea0e484bd10cd2dc37610287ce49388c5/librt-0.8.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fd1a720332ea335ceb544cf0a03f81df92abd4bb887679fd1e460976b0e6214b", size = 218750 },
+    { url = "https://files.pythonhosted.org/packages/71/67/5a387bfef30ec1e4b4f30562c8586566faf87e47d696768c19feb49e3646/librt-0.8.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2af9e01e0ef80d95ae3c720be101227edae5f2fe7e3dc63d8857fadfc5a1d", size = 241624 },
+    { url = "https://files.pythonhosted.org/packages/d4/be/24f8502db11d405232ac1162eb98069ca49c3306c1d75c6ccc61d9af8789/librt-0.8.1-cp313-cp313-win32.whl", hash = "sha256:086a32dbb71336627e78cc1d6ee305a68d038ef7d4c39aaff41ae8c9aa46e91a", size = 54969 },
+    { url = "https://files.pythonhosted.org/packages/5c/73/c9fdf6cb2a529c1a092ce769a12d88c8cca991194dfe641b6af12fa964d2/librt-0.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:e11769a1dbda4da7b00a76cfffa67aa47cfa66921d2724539eee4b9ede780b79", size = 62000 },
+    { url = "https://files.pythonhosted.org/packages/d3/97/68f80ca3ac4924f250cdfa6e20142a803e5e50fca96ef5148c52ee8c10ea/librt-0.8.1-cp313-cp313-win_arm64.whl", hash = "sha256:924817ab3141aca17893386ee13261f1d100d1ef410d70afe4389f2359fea4f0", size = 52495 },
+    { url = "https://files.pythonhosted.org/packages/c9/6a/907ef6800f7bca71b525a05f1839b21f708c09043b1c6aa77b6b827b3996/librt-0.8.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6cfa7fe54fd4d1f47130017351a959fe5804bda7a0bc7e07a2cdbc3fdd28d34f", size = 66081 },
+    { url = "https://files.pythonhosted.org/packages/1b/18/25e991cd5640c9fb0f8d91b18797b29066b792f17bf8493da183bf5caabe/librt-0.8.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:228c2409c079f8c11fb2e5d7b277077f694cb93443eb760e00b3b83cb8b3176c", size = 68309 },
+    { url = "https://files.pythonhosted.org/packages/a4/36/46820d03f058cfb5a9de5940640ba03165ed8aded69e0733c417bb04df34/librt-0.8.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7aae78ab5e3206181780e56912d1b9bb9f90a7249ce12f0e8bf531d0462dd0fc", size = 196804 },
+    { url = "https://files.pythonhosted.org/packages/59/18/5dd0d3b87b8ff9c061849fbdb347758d1f724b9a82241aa908e0ec54ccd0/librt-0.8.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:172d57ec04346b047ca6af181e1ea4858086c80bdf455f61994c4aa6fc3f866c", size = 206907 },
+    { url = "https://files.pythonhosted.org/packages/d1/96/ef04902aad1424fd7299b62d1890e803e6ab4018c3044dca5922319c4b97/librt-0.8.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b1977c4ea97ce5eb7755a78fae68d87e4102e4aaf54985e8b56806849cc06a3", size = 221217 },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/7e01f2dda84a8f5d280637a2e5827210a8acca9a567a54507ef1c75b342d/librt-0.8.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10c42e1f6fd06733ef65ae7bebce2872bcafd8d6e6b0a08fe0a05a23b044fb14", size = 214622 },
+    { url = "https://files.pythonhosted.org/packages/1e/8c/5b093d08a13946034fed57619742f790faf77058558b14ca36a6e331161e/librt-0.8.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4c8dfa264b9193c4ee19113c985c95f876fae5e51f731494fc4e0cf594990ba7", size = 221987 },
+    { url = "https://files.pythonhosted.org/packages/d3/cc/86b0b3b151d40920ad45a94ce0171dec1aebba8a9d72bb3fa00c73ab25dd/librt-0.8.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:01170b6729a438f0dedc4a26ed342e3dc4f02d1000b4b19f980e1877f0c297e6", size = 215132 },
+    { url = "https://files.pythonhosted.org/packages/fc/be/8588164a46edf1e69858d952654e216a9a91174688eeefb9efbb38a9c799/librt-0.8.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:7b02679a0d783bdae30d443025b94465d8c3dc512f32f5b5031f93f57ac32071", size = 215195 },
+    { url = "https://files.pythonhosted.org/packages/f5/f2/0b9279bea735c734d69344ecfe056c1ba211694a72df10f568745c899c76/librt-0.8.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:190b109bb69592a3401fe1ffdea41a2e73370ace2ffdc4a0e8e2b39cdea81b78", size = 237946 },
+    { url = "https://files.pythonhosted.org/packages/e9/cc/5f2a34fbc8aeb35314a3641f9956fa9051a947424652fad9882be7a97949/librt-0.8.1-cp314-cp314-win32.whl", hash = "sha256:e70a57ecf89a0f64c24e37f38d3fe217a58169d2fe6ed6d70554964042474023", size = 50689 },
+    { url = "https://files.pythonhosted.org/packages/a0/76/cd4d010ab2147339ca2b93e959c3686e964edc6de66ddacc935c325883d7/librt-0.8.1-cp314-cp314-win_amd64.whl", hash = "sha256:7e2f3edca35664499fbb36e4770650c4bd4a08abc1f4458eab9df4ec56389730", size = 57875 },
+    { url = "https://files.pythonhosted.org/packages/84/0f/2143cb3c3ca48bd3379dcd11817163ca50781927c4537345d608b5045998/librt-0.8.1-cp314-cp314-win_arm64.whl", hash = "sha256:0d2f82168e55ddefd27c01c654ce52379c0750ddc31ee86b4b266bcf4d65f2a3", size = 48058 },
+    { url = "https://files.pythonhosted.org/packages/d2/0e/9b23a87e37baf00311c3efe6b48d6b6c168c29902dfc3f04c338372fd7db/librt-0.8.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2c74a2da57a094bd48d03fa5d196da83d2815678385d2978657499063709abe1", size = 68313 },
+    { url = "https://files.pythonhosted.org/packages/db/9a/859c41e5a4f1c84200a7d2b92f586aa27133c8243b6cac9926f6e54d01b9/librt-0.8.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a355d99c4c0d8e5b770313b8b247411ed40949ca44e33e46a4789b9293a907ee", size = 70994 },
+    { url = "https://files.pythonhosted.org/packages/4c/28/10605366ee599ed34223ac2bf66404c6fb59399f47108215d16d5ad751a8/librt-0.8.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2eb345e8b33fb748227409c9f1233d4df354d6e54091f0e8fc53acdb2ffedeb7", size = 220770 },
+    { url = "https://files.pythonhosted.org/packages/af/8d/16ed8fd452dafae9c48d17a6bc1ee3e818fd40ef718d149a8eff2c9f4ea2/librt-0.8.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9be2f15e53ce4e83cc08adc29b26fb5978db62ef2a366fbdf716c8a6c8901040", size = 235409 },
+    { url = "https://files.pythonhosted.org/packages/89/1b/7bdf3e49349c134b25db816e4a3db6b94a47ac69d7d46b1e682c2c4949be/librt-0.8.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:785ae29c1f5c6e7c2cde2c7c0e148147f4503da3abc5d44d482068da5322fd9e", size = 246473 },
+    { url = "https://files.pythonhosted.org/packages/4e/8a/91fab8e4fd2a24930a17188c7af5380eb27b203d72101c9cc000dbdfd95a/librt-0.8.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d3a7da44baf692f0c6aeb5b2a09c5e6fc7a703bca9ffa337ddd2e2da53f7732", size = 238866 },
+    { url = "https://files.pythonhosted.org/packages/b9/e0/c45a098843fc7c07e18a7f8a24ca8496aecbf7bdcd54980c6ca1aaa79a8e/librt-0.8.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5fc48998000cbc39ec0d5311312dda93ecf92b39aaf184c5e817d5d440b29624", size = 250248 },
+    { url = "https://files.pythonhosted.org/packages/82/30/07627de23036640c952cce0c1fe78972e77d7d2f8fd54fa5ef4554ff4a56/librt-0.8.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e96baa6820280077a78244b2e06e416480ed859bbd8e5d641cf5742919d8beb4", size = 240629 },
+    { url = "https://files.pythonhosted.org/packages/fb/c1/55bfe1ee3542eba055616f9098eaf6eddb966efb0ca0f44eaa4aba327307/librt-0.8.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:31362dbfe297b23590530007062c32c6f6176f6099646bb2c95ab1b00a57c382", size = 239615 },
+    { url = "https://files.pythonhosted.org/packages/2b/39/191d3d28abc26c9099b19852e6c99f7f6d400b82fa5a4e80291bd3803e19/librt-0.8.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc3656283d11540ab0ea01978378e73e10002145117055e03722417aeab30994", size = 263001 },
+    { url = "https://files.pythonhosted.org/packages/b9/eb/7697f60fbe7042ab4e88f4ee6af496b7f222fffb0a4e3593ef1f29f81652/librt-0.8.1-cp314-cp314t-win32.whl", hash = "sha256:738f08021b3142c2918c03692608baed43bc51144c29e35807682f8070ee2a3a", size = 51328 },
+    { url = "https://files.pythonhosted.org/packages/7c/72/34bf2eb7a15414a23e5e70ecb9440c1d3179f393d9349338a91e2781c0fb/librt-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89815a22daf9c51884fb5dbe4f1ef65ee6a146e0b6a8df05f753e2e4a9359bf4", size = 58722 },
+    { url = "https://files.pythonhosted.org/packages/b2/c8/d148e041732d631fc76036f8b30fae4e77b027a1e95b7a84bb522481a940/librt-0.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:bf512a71a23504ed08103a13c941f763db13fb11177beb3d9244c98c29fb4a61", size = 48755 },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -702,6 +749,42 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819 },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426 },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146 },
+]
+
+[[package]]
+name = "mypy"
+version = "1.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/db/4efed9504bc01309ab9c2da7e352cc223569f05478012b5d9ece38fd44d2/mypy-1.19.1.tar.gz", hash = "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba", size = 3582404 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/9f/a6abae693f7a0c697dbb435aac52e958dc8da44e92e08ba88d2e42326176/mypy-1.19.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e3157c7594ff2ef1634ee058aafc56a82db665c9438fd41b390f3bde1ab12250", size = 13201927 },
+    { url = "https://files.pythonhosted.org/packages/9a/a4/45c35ccf6e1c65afc23a069f50e2c66f46bd3798cbe0d680c12d12935caa/mypy-1.19.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdb12f69bcc02700c2b47e070238f42cb87f18c0bc1fc4cdb4fb2bc5fd7a3b8b", size = 12206730 },
+    { url = "https://files.pythonhosted.org/packages/05/bb/cdcf89678e26b187650512620eec8368fded4cfd99cfcb431e4cdfd19dec/mypy-1.19.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f859fb09d9583a985be9a493d5cfc5515b56b08f7447759a0c5deaf68d80506e", size = 12724581 },
+    { url = "https://files.pythonhosted.org/packages/d1/32/dd260d52babf67bad8e6770f8e1102021877ce0edea106e72df5626bb0ec/mypy-1.19.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9a6538e0415310aad77cb94004ca6482330fece18036b5f360b62c45814c4ef", size = 13616252 },
+    { url = "https://files.pythonhosted.org/packages/71/d0/5e60a9d2e3bd48432ae2b454b7ef2b62a960ab51292b1eda2a95edd78198/mypy-1.19.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:da4869fc5e7f62a88f3fe0b5c919d1d9f7ea3cef92d3689de2823fd27e40aa75", size = 13840848 },
+    { url = "https://files.pythonhosted.org/packages/98/76/d32051fa65ecf6cc8c6610956473abdc9b4c43301107476ac03559507843/mypy-1.19.1-cp313-cp313-win_amd64.whl", hash = "sha256:016f2246209095e8eda7538944daa1d60e1e8134d98983b9fc1e92c1fc0cb8dd", size = 10135510 },
+    { url = "https://files.pythonhosted.org/packages/de/eb/b83e75f4c820c4247a58580ef86fcd35165028f191e7e1ba57128c52782d/mypy-1.19.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06e6170bd5836770e8104c8fdd58e5e725cfeb309f0a6c681a811f557e97eac1", size = 13199744 },
+    { url = "https://files.pythonhosted.org/packages/94/28/52785ab7bfa165f87fcbb61547a93f98bb20e7f82f90f165a1f69bce7b3d/mypy-1.19.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:804bd67b8054a85447c8954215a906d6eff9cabeabe493fb6334b24f4bfff718", size = 12215815 },
+    { url = "https://files.pythonhosted.org/packages/0a/c6/bdd60774a0dbfb05122e3e925f2e9e846c009e479dcec4821dad881f5b52/mypy-1.19.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21761006a7f497cb0d4de3d8ef4ca70532256688b0523eee02baf9eec895e27b", size = 12740047 },
+    { url = "https://files.pythonhosted.org/packages/32/2a/66ba933fe6c76bd40d1fe916a83f04fed253152f451a877520b3c4a5e41e/mypy-1.19.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28902ee51f12e0f19e1e16fbe2f8f06b6637f482c459dd393efddd0ec7f82045", size = 13601998 },
+    { url = "https://files.pythonhosted.org/packages/e3/da/5055c63e377c5c2418760411fd6a63ee2b96cf95397259038756c042574f/mypy-1.19.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:481daf36a4c443332e2ae9c137dfee878fcea781a2e3f895d54bd3002a900957", size = 13807476 },
+    { url = "https://files.pythonhosted.org/packages/cd/09/4ebd873390a063176f06b0dbf1f7783dd87bd120eae7727fa4ae4179b685/mypy-1.19.1-cp314-cp314-win_amd64.whl", hash = "sha256:8bb5c6f6d043655e055be9b542aa5f3bdd30e4f3589163e85f93f3640060509f", size = 10281872 },
+    { url = "https://files.pythonhosted.org/packages/8d/f4/4ce9a05ce5ded1de3ec1c1d96cf9f9504a04e54ce0ed55cfa38619a32b8d/mypy-1.19.1-py3-none-any.whl", hash = "sha256:f1235f5ea01b7db5468d53ece6aaddf1ad0b88d9e7462b86ef96fe04995d7247", size = 2471239 },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963 },
 ]
 
 [[package]]
@@ -812,6 +895,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/1e/1bac1a839d12e6a82ec6cb40cda2edde64a2013a66963293696bbf31fbbb/pandas-2.3.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e3ebdb170b5ef78f19bfb71b0dc5dc58775032361fa188e814959b74d726dd5", size = 12121582 },
     { url = "https://files.pythonhosted.org/packages/44/91/483de934193e12a3b1d6ae7c8645d083ff88dec75f46e827562f1e4b4da6/pandas-2.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d051c0e065b94b7a3cea50eb1ec32e912cd96dba41647eb24104b6c6c14c5788", size = 12699963 },
     { url = "https://files.pythonhosted.org/packages/70/44/5191d2e4026f86a2a109053e194d3ba7a31a2d10a9c2348368c63ed4e85a/pandas-2.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3869faf4bd07b3b66a9f462417d0ca3a9df29a9f6abd5d0d0dbab15dac7abe87", size = 13202175 },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206 },
 ]
 
 [[package]]
@@ -1066,6 +1158,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/04/eab13a954e763b0606f460443fcbf6bb5a0faf06890ea3754ff16523dce5/ruff-0.15.2.tar.gz", hash = "sha256:14b965afee0969e68bb871eba625343b8673375f457af4abe98553e8bbb98342", size = 4558148 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/70/3a4dc6d09b13cb3e695f28307e5d889b2e1a66b7af9c5e257e796695b0e6/ruff-0.15.2-py3-none-linux_armv6l.whl", hash = "sha256:120691a6fdae2f16d65435648160f5b81a9625288f75544dc40637436b5d3c0d", size = 10430565 },
+    { url = "https://files.pythonhosted.org/packages/71/0b/bb8457b56185ece1305c666dc895832946d24055be90692381c31d57466d/ruff-0.15.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a89056d831256099658b6bba4037ac6dd06f49d194199215befe2bb10457ea5e", size = 10820354 },
+    { url = "https://files.pythonhosted.org/packages/2d/c1/e0532d7f9c9e0b14c46f61b14afd563298b8b83f337b6789ddd987e46121/ruff-0.15.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e36dee3a64be0ebd23c86ffa3aa3fd3ac9a712ff295e192243f814a830b6bd87", size = 10170767 },
+    { url = "https://files.pythonhosted.org/packages/47/e8/da1aa341d3af017a21c7a62fb5ec31d4e7ad0a93ab80e3a508316efbcb23/ruff-0.15.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9fb47b6d9764677f8c0a193c0943ce9a05d6763523f132325af8a858eadc2b9", size = 10529591 },
+    { url = "https://files.pythonhosted.org/packages/93/74/184fbf38e9f3510231fbc5e437e808f0b48c42d1df9434b208821efcd8d6/ruff-0.15.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f376990f9d0d6442ea9014b19621d8f2aaf2b8e39fdbfc79220b7f0c596c9b80", size = 10260771 },
+    { url = "https://files.pythonhosted.org/packages/05/ac/605c20b8e059a0bc4b42360414baa4892ff278cec1c91fff4be0dceedefd/ruff-0.15.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2dcc987551952d73cbf5c88d9fdee815618d497e4df86cd4c4824cc59d5dd75f", size = 11045791 },
+    { url = "https://files.pythonhosted.org/packages/fd/52/db6e419908f45a894924d410ac77d64bdd98ff86901d833364251bd08e22/ruff-0.15.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:42a47fd785cbe8c01b9ff45031af875d101b040ad8f4de7bbb716487c74c9a77", size = 11879271 },
+    { url = "https://files.pythonhosted.org/packages/3e/d8/7992b18f2008bdc9231d0f10b16df7dda964dbf639e2b8b4c1b4e91b83af/ruff-0.15.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cbe9f49354866e575b4c6943856989f966421870e85cd2ac94dccb0a9dcb2fea", size = 11303707 },
+    { url = "https://files.pythonhosted.org/packages/d7/02/849b46184bcfdd4b64cde61752cc9a146c54759ed036edd11857e9b8443b/ruff-0.15.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7a672c82b5f9887576087d97be5ce439f04bbaf548ee987b92d3a7dede41d3a", size = 11149151 },
+    { url = "https://files.pythonhosted.org/packages/70/04/f5284e388bab60d1d3b99614a5a9aeb03e0f333847e2429bebd2aaa1feec/ruff-0.15.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ecc64f46f7019e2bcc3cdc05d4a7da958b629a5ab7033195e11a438403d956", size = 11091132 },
+    { url = "https://files.pythonhosted.org/packages/fa/ae/88d844a21110e14d92cf73d57363fab59b727ebeabe78009b9ccb23500af/ruff-0.15.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:8dcf243b15b561c655c1ef2f2b0050e5d50db37fe90115507f6ff37d865dc8b4", size = 10504717 },
+    { url = "https://files.pythonhosted.org/packages/64/27/867076a6ada7f2b9c8292884ab44d08fd2ba71bd2b5364d4136f3cd537e1/ruff-0.15.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dab6941c862c05739774677c6273166d2510d254dac0695c0e3f5efa1b5585de", size = 10263122 },
+    { url = "https://files.pythonhosted.org/packages/e7/ef/faf9321d550f8ebf0c6373696e70d1758e20ccdc3951ad7af00c0956be7c/ruff-0.15.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b9164f57fc36058e9a6806eb92af185b0697c9fe4c7c52caa431c6554521e5c", size = 10735295 },
+    { url = "https://files.pythonhosted.org/packages/2f/55/e8089fec62e050ba84d71b70e7834b97709ca9b7aba10c1a0b196e493f97/ruff-0.15.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:80d24fcae24d42659db7e335b9e1531697a7102c19185b8dc4a028b952865fd8", size = 11241641 },
+    { url = "https://files.pythonhosted.org/packages/23/01/1c30526460f4d23222d0fabd5888868262fd0e2b71a00570ca26483cd993/ruff-0.15.2-py3-none-win32.whl", hash = "sha256:fd5ff9e5f519a7e1bd99cbe8daa324010a74f5e2ebc97c6242c08f26f3714f6f", size = 10507885 },
+    { url = "https://files.pythonhosted.org/packages/5c/10/3d18e3bbdf8fc50bbb4ac3cc45970aa5a9753c5cb51bf9ed9a3cd8b79fa3/ruff-0.15.2-py3-none-win_amd64.whl", hash = "sha256:d20014e3dfa400f3ff84830dfb5755ece2de45ab62ecea4af6b7262d0fb4f7c5", size = 11623725 },
+    { url = "https://files.pythonhosted.org/packages/6d/78/097c0798b1dab9f8affe73da9642bb4500e098cb27fd8dc9724816ac747b/ruff-0.15.2-py3-none-win_arm64.whl", hash = "sha256:cabddc5822acdc8f7b5527b36ceac55cc51eec7b1946e60181de8fe83ca8876e", size = 10941649 },
+]
+
+[[package]]
 name = "school-ai-app"
 version = "0.1.0"
 source = { virtual = "." }
@@ -1083,8 +1200,10 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -1094,10 +1213,12 @@ requires-dist = [
     { name = "google-auth-httplib2", specifier = ">=0.2.1" },
     { name = "google-auth-oauthlib", specifier = ">=1.2.3" },
     { name = "google-cloud-aiplatform", specifier = ">=1.129.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.0" },
     { name = "slack-sdk", specifier = ">=3.39.0" },
     { name = "todoist-api-python", specifier = ">=3.1.0" },
 ]

--- a/v2/adapters/credentials.py
+++ b/v2/adapters/credentials.py
@@ -9,35 +9,38 @@ Cloud Functions環境ではApplication Default Credentials (ADC)を使用。
 import os
 import pickle
 from functools import lru_cache
+
+import google.auth
 from google.auth.transport.requests import Request
+from google.oauth2 import service_account
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
-from google.oauth2 import service_account
-import google.auth
 
 # Google API のスコープ
 SCOPES = [
-    'https://www.googleapis.com/auth/spreadsheets.readonly',
-    'https://www.googleapis.com/auth/drive',
-    'https://www.googleapis.com/auth/calendar',
-    'https://www.googleapis.com/auth/chat.messages',
-    'https://www.googleapis.com/auth/chat.spaces.readonly',
-    'https://www.googleapis.com/auth/tasks',
-    'https://www.googleapis.com/auth/cloud-platform'
+    "https://www.googleapis.com/auth/spreadsheets.readonly",
+    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/calendar",
+    "https://www.googleapis.com/auth/chat.messages",
+    "https://www.googleapis.com/auth/chat.spaces.readonly",
+    "https://www.googleapis.com/auth/tasks",
+    "https://www.googleapis.com/auth/cloud-platform",
 ]
 
 
 def _is_cloud_function_environment() -> bool:
     """Cloud Functions環境かどうかを判定"""
     # Cloud Functionsでは K_SERVICE 環境変数が設定される
-    return os.getenv('K_SERVICE') is not None or os.getenv('FUNCTION_TARGET') is not None
+    return (
+        os.getenv("K_SERVICE") is not None or os.getenv("FUNCTION_TARGET") is not None
+    )
 
 
 @lru_cache(maxsize=1)
 def get_google_credentials(
-    token_pickle_path: str = 'token.pickle',
-    credentials_json_path: str = 'credentials.json',
-    service_account_path: str = 'service_account.json',
+    token_pickle_path: str = "token.pickle",
+    credentials_json_path: str = "credentials.json",
+    service_account_path: str = "service_account.json",
 ) -> Credentials:
     """
     Google API認証情報を取得（シングルトン）。
@@ -70,7 +73,7 @@ def get_google_credentials(
 
     # 1. 既存のOAuth認証情報を読み込み
     if os.path.exists(token_pickle_path):
-        with open(token_pickle_path, 'rb') as token:
+        with open(token_pickle_path, "rb") as token:
             creds = pickle.load(token)
 
     # 2. 認証情報の有効性チェック
@@ -99,7 +102,7 @@ def get_google_credentials(
 
         # 3. OAuth認証情報をキャッシュ（サービスアカウントの場合は不要）
         if not isinstance(creds, service_account.Credentials):
-            with open(token_pickle_path, 'wb') as token:
+            with open(token_pickle_path, "wb") as token:
                 pickle.dump(creds, token)
 
     return creds

--- a/v2/adapters/google_calendar.py
+++ b/v2/adapters/google_calendar.py
@@ -5,10 +5,12 @@ CalendarService ABCの実装。
 """
 
 import logging
+
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
-from v2.domain.ports import CalendarService
+
 from v2.domain.models import EventData
+from v2.domain.ports import CalendarService
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +31,7 @@ class GoogleCalendarService(CalendarService):
         if not credentials:
             raise ValueError("credentials is required")
 
-        self._service = build('calendar', 'v3', credentials=credentials)
+        self._service = build("calendar", "v3", credentials=credentials)
         self._timezone = timezone
 
     def create_event(
@@ -61,28 +63,25 @@ class GoogleCalendarService(CalendarService):
 
             # イベントボディ構築
             event_body = {
-                'summary': event.summary or 'No Title',
-                'location': event.location,
-                'description': description,
-                'start': start_body,
-                'end': end_body,
+                "summary": event.summary or "No Title",
+                "location": event.location,
+                "description": description,
+                "start": start_body,
+                "end": end_body,
             }
 
             # Calendar API呼び出し
-            created_event = self._service.events().insert(
-                calendarId=calendar_id,
-                body=event_body
-            ).execute()
-
-            event_url = created_event.get('htmlLink', '')
-            logger.info(
-                "Created calendar event: %s (%s)",
-                event.summary,
-                event_url
+            created_event = (
+                self._service.events()
+                .insert(calendarId=calendar_id, body=event_body)
+                .execute()
             )
+
+            event_url = created_event.get("htmlLink", "")
+            logger.info("Created calendar event: %s (%s)", event.summary, event_url)
             return event_url
 
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to create calendar event: %s", event.summary)
             raise
 
@@ -98,10 +97,7 @@ class GoogleCalendarService(CalendarService):
         """
         if len(datetime_str) == 10:
             # 終日イベント（YYYY-MM-DD）
-            return {'date': datetime_str}
+            return {"date": datetime_str}
         else:
             # 時刻指定イベント（ISO8601）
-            return {
-                'dateTime': datetime_str,
-                'timeZone': self._timezone
-            }
+            return {"dateTime": datetime_str, "timeZone": self._timezone}

--- a/v2/adapters/google_drive.py
+++ b/v2/adapters/google_drive.py
@@ -6,11 +6,13 @@ FileStorage ABCの実装。
 
 import io
 import logging
+
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseDownload
-from v2.domain.ports import FileStorage
+
 from v2.domain.models import FileInfo
+from v2.domain.ports import FileStorage
 
 logger = logging.getLogger(__name__)
 
@@ -23,10 +25,7 @@ class GoogleDriveStorage(FileStorage):
     """
 
     def __init__(
-        self,
-        credentials: Credentials,
-        inbox_folder_id: str,
-        archive_folder_id: str
+        self, credentials: Credentials, inbox_folder_id: str, archive_folder_id: str
     ):
         """
         Args:
@@ -41,7 +40,7 @@ class GoogleDriveStorage(FileStorage):
         if not archive_folder_id:
             raise ValueError("archive_folder_id is required")
 
-        self._service = build('drive', 'v3', credentials=credentials)
+        self._service = build("drive", "v3", credentials=credentials)
         self._inbox_id = inbox_folder_id
         self._archive_id = archive_folder_id
 
@@ -56,19 +55,23 @@ class GoogleDriveStorage(FileStorage):
             Exception: Drive API呼び出しに失敗した場合
         """
         try:
-            results = self._service.files().list(
-                q=f"'{self._inbox_id}' in parents and trashed = false",
-                fields="nextPageToken, files(id, name, mimeType, webViewLink)",
-                pageSize=100
-            ).execute()
+            results = (
+                self._service.files()
+                .list(
+                    q=f"'{self._inbox_id}' in parents and trashed = false",
+                    fields="nextPageToken, files(id, name, mimeType, webViewLink)",
+                    pageSize=100,
+                )
+                .execute()
+            )
 
-            items = results.get('files', [])
+            items = results.get("files", [])
             file_infos = [
                 FileInfo(
-                    id=item['id'],
-                    name=item['name'],
-                    mime_type=item['mimeType'],
-                    web_view_link=item.get('webViewLink', '')
+                    id=item["id"],
+                    name=item["name"],
+                    mime_type=item["mimeType"],
+                    web_view_link=item.get("webViewLink", ""),
                 )
                 for item in items
             ]
@@ -76,7 +79,7 @@ class GoogleDriveStorage(FileStorage):
             logger.info("Found %d files in Inbox folder", len(file_infos))
             return file_infos
 
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to list files in Inbox folder")
             raise
 
@@ -110,7 +113,7 @@ class GoogleDriveStorage(FileStorage):
             logger.info("Downloaded file: %s (%d bytes)", file_id, len(content))
             return content
 
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to download file: %s", file_id)
             raise
 
@@ -127,27 +130,25 @@ class GoogleDriveStorage(FileStorage):
         """
         try:
             # 1. 現在の親フォルダを取得
-            file = self._service.files().get(
-                fileId=file_id, fields='parents'
-            ).execute()
-            previous_parents = ",".join(file.get('parents', []))
+            file = self._service.files().get(fileId=file_id, fields="parents").execute()
+            previous_parents = ",".join(file.get("parents", []))
 
             # 2. Archiveフォルダに移動 + リネーム
             self._service.files().update(
                 fileId=file_id,
                 addParents=self._archive_id,
                 removeParents=previous_parents,
-                body={'name': new_name},
-                fields='id, parents'
+                body={"name": new_name},
+                fields="id, parents",
             ).execute()
 
             logger.info(
                 "Archived file: %s -> %s (moved to %s)",
                 file_id,
                 new_name,
-                self._archive_id
+                self._archive_id,
             )
 
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to archive file: %s", file_id)
             raise

--- a/v2/adapters/google_sheets.py
+++ b/v2/adapters/google_sheets.py
@@ -5,10 +5,12 @@ ConfigSource ABCの実装。
 """
 
 import logging
+
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
-from v2.domain.ports import ConfigSource
+
 from v2.domain.models import Profile, Rule
+from v2.domain.ports import ConfigSource
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +35,7 @@ class GoogleSheetsConfigSource(ConfigSource):
         if not spreadsheet_id:
             raise ValueError("spreadsheet_id is required")
 
-        self._service = build('sheets', 'v4', credentials=credentials)
+        self._service = build("sheets", "v4", credentials=credentials)
         self._spreadsheet_id = spreadsheet_id
 
     def load_profiles(self) -> dict[str, Profile]:
@@ -47,12 +49,14 @@ class GoogleSheetsConfigSource(ConfigSource):
             Exception: シート読み込みに失敗した場合
         """
         try:
-            result = self._service.spreadsheets().values().get(
-                spreadsheetId=self._spreadsheet_id,
-                range='Profiles!A2:E'
-            ).execute()
+            result = (
+                self._service.spreadsheets()
+                .values()
+                .get(spreadsheetId=self._spreadsheet_id, range="Profiles!A2:E")
+                .execute()
+            )
 
-            rows = result.get('values', [])
+            rows = result.get("values", [])
             profiles = {}
 
             for row in rows:
@@ -60,16 +64,16 @@ class GoogleSheetsConfigSource(ConfigSource):
                     profile_id = row[0]
                     profiles[profile_id] = Profile(
                         id=profile_id,
-                        name=row[1] if len(row) > 1 else '',
-                        grade=row[2] if len(row) > 2 else '',
-                        keywords=row[3] if len(row) > 3 else '',
-                        calendar_id=row[4] if len(row) > 4 else '',
+                        name=row[1] if len(row) > 1 else "",
+                        grade=row[2] if len(row) > 2 else "",
+                        keywords=row[3] if len(row) > 3 else "",
+                        calendar_id=row[4] if len(row) > 4 else "",
                     )
 
             logger.info("Loaded %d profiles from Google Sheets", len(profiles))
             return profiles
 
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to load profiles from Google Sheets")
             raise
 
@@ -84,26 +88,30 @@ class GoogleSheetsConfigSource(ConfigSource):
             Exception: シート読み込みに失敗した場合
         """
         try:
-            result = self._service.spreadsheets().values().get(
-                spreadsheetId=self._spreadsheet_id,
-                range='Rules!A2:D'
-            ).execute()
+            result = (
+                self._service.spreadsheets()
+                .values()
+                .get(spreadsheetId=self._spreadsheet_id, range="Rules!A2:D")
+                .execute()
+            )
 
-            rows = result.get('values', [])
+            rows = result.get("values", [])
             rules = []
 
             for row in rows:
                 if len(row) > 0:
-                    rules.append(Rule(
-                        rule_id=row[0],
-                        target_profile=row[1] if len(row) > 1 else '',
-                        rule_type=row[2] if len(row) > 2 else '',
-                        content=row[3] if len(row) > 3 else '',
-                    ))
+                    rules.append(
+                        Rule(
+                            rule_id=row[0],
+                            target_profile=row[1] if len(row) > 1 else "",
+                            rule_type=row[2] if len(row) > 2 else "",
+                            content=row[3] if len(row) > 3 else "",
+                        )
+                    )
 
             logger.info("Loaded %d rules from Google Sheets", len(rules))
             return rules
 
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to load rules from Google Sheets")
             raise

--- a/v2/adapters/slack.py
+++ b/v2/adapters/slack.py
@@ -5,10 +5,12 @@ Notifier ABCの実装。
 """
 
 import logging
+
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
-from v2.domain.ports import Notifier
+
 from v2.domain.models import EventData, TaskData
+from v2.domain.ports import Notifier
 
 logger = logging.getLogger(__name__)
 
@@ -59,18 +61,15 @@ class SlackNotifier(Notifier):
 
         try:
             response = self._client.chat_postMessage(
-                channel=self._channel_id,
-                text=message
+                channel=self._channel_id, text=message
             )
             logger.info(
                 "Slack message sent: ts=%s, channel=%s",
-                response['ts'],
-                self._channel_id
+                response["ts"],
+                self._channel_id,
             )
         except SlackApiError as e:
-            logger.error(
-                "Failed to send Slack message: %s", e.response['error']
-            )
+            logger.error("Failed to send Slack message: %s", e.response["error"])
             raise  # 呼び出し元でエラーハンドリング
 
     def _build_message(

--- a/v2/adapters/todoist.py
+++ b/v2/adapters/todoist.py
@@ -5,10 +5,11 @@ TaskService ABCの実装。
 """
 
 import logging
-from typing import Optional
+
 from todoist_api_python.api import TodoistAPI
-from v2.domain.ports import TaskService
+
 from v2.domain.models import TaskData
+from v2.domain.ports import TaskService
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,7 @@ class TodoistAdapter(TaskService):
     - エラーハンドリング改善
     """
 
-    def __init__(self, api_token: str, project_id: Optional[str] = None):
+    def __init__(self, api_token: str, project_id: str | None = None):
         """
         Args:
             api_token: Todoist API Token
@@ -71,10 +72,10 @@ class TodoistAdapter(TaskService):
             logger.info(
                 "Created Todoist task: %s (ID: %s)",
                 created_task.content,
-                created_task.id
+                created_task.id,
             )
             return created_task.id
 
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to create Todoist task: %s", task.title)
             raise  # 呼び出し元でエラーハンドリング

--- a/v2/config.py
+++ b/v2/config.py
@@ -2,12 +2,14 @@
 
 import os
 from dataclasses import dataclass
+
 from dotenv import load_dotenv
 
 
 @dataclass(frozen=True)
 class AppConfig:
     """アプリケーション設定"""
+
     project_id: str
     spreadsheet_id: str
     inbox_folder_id: str

--- a/v2/domain/__init__.py
+++ b/v2/domain/__init__.py
@@ -1,29 +1,29 @@
 """Domain layer - 外部依存なしのドメインモデルとインターフェース定義"""
 
-from v2.domain.models import (
-    Category,
-    Profile,
-    Rule,
-    EventData,
-    TaskData,
-    DocumentAnalysis,
-    FileInfo,
-    ProcessingResult,
-)
 from v2.domain.errors import (
-    SchoolAgentError,
+    ActionError,
+    AnalysisError,
     ConfigLoadError,
     FileDownloadError,
-    AnalysisError,
-    ActionError,
+    SchoolAgentError,
+)
+from v2.domain.models import (
+    Category,
+    DocumentAnalysis,
+    EventData,
+    FileInfo,
+    ProcessingResult,
+    Profile,
+    Rule,
+    TaskData,
 )
 from v2.domain.ports import (
-    ConfigSource,
-    FileStorage,
-    DocumentAnalyzer,
     CalendarService,
-    TaskService,
+    ConfigSource,
+    DocumentAnalyzer,
+    FileStorage,
     Notifier,
+    TaskService,
 )
 
 __all__ = [

--- a/v2/domain/errors.py
+++ b/v2/domain/errors.py
@@ -3,24 +3,29 @@
 
 class SchoolAgentError(Exception):
     """School Agent の基底例外"""
+
     pass
 
 
 class ConfigLoadError(SchoolAgentError):
     """設定読み込みエラー（Google Sheets等）"""
+
     pass
 
 
 class FileDownloadError(SchoolAgentError):
     """ファイルダウンロードエラー"""
+
     pass
 
 
 class AnalysisError(SchoolAgentError):
     """文書解析エラー（Gemini API等）"""
+
     pass
 
 
 class ActionError(SchoolAgentError):
     """アクション実行エラー（Calendar/Todoist/Slack等）"""
+
     pass

--- a/v2/domain/models.py
+++ b/v2/domain/models.py
@@ -1,13 +1,14 @@
 """ドメインモデル - 外部依存なしのデータ構造"""
 
 from __future__ import annotations
+
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional
 
 
 class Category(Enum):
     """文書のカテゴリ"""
+
     EVENT = "EVENT"
     TASK = "TASK"
     INFO = "INFO"
@@ -17,29 +18,32 @@ class Category(Enum):
 @dataclass(frozen=True)
 class Profile:
     """家族メンバーのプロファイル"""
-    id: str              # 例: "CHILD1"
-    name: str            # 例: "太郎"
-    grade: str           # 例: "小3"
-    keywords: str        # 例: "サッカー,遠足"
-    calendar_id: str     # 例: "c_abc123@group.calendar.google.com"
+
+    id: str  # 例: "CHILD1"
+    name: str  # 例: "太郎"
+    grade: str  # 例: "小3"
+    keywords: str  # 例: "サッカー,遠足"
+    calendar_id: str  # 例: "c_abc123@group.calendar.google.com"
 
 
 @dataclass(frozen=True)
 class Rule:
     """処理ルール"""
-    rule_id: str         # 例: "R001"
+
+    rule_id: str  # 例: "R001"
     target_profile: str  # 例: "CHILD1" or "ALL"
-    rule_type: str       # 例: "REMINDER", "IGNORE", "NAMING"
-    content: str         # 例: "持ち物が必要なイベントは3日前にタスク期限を設定"
+    rule_type: str  # 例: "REMINDER", "IGNORE", "NAMING"
+    content: str  # 例: "持ち物が必要なイベントは3日前にタスク期限を設定"
 
 
 @dataclass(frozen=True)
 class EventData:
     """カレンダーイベントデータ"""
-    summary: str         # 例: "[長男] 遠足"
-    start: str           # ISO8601: "2025-10-25T08:30:00" or "2025-10-25"
-    end: str             # ISO8601: "2025-10-25T15:00:00" or "2025-10-25"
-    location: str = ""   # 例: "動物園"
+
+    summary: str  # 例: "[長男] 遠足"
+    start: str  # ISO8601: "2025-10-25T08:30:00" or "2025-10-25"
+    end: str  # ISO8601: "2025-10-25T15:00:00" or "2025-10-25"
+    location: str = ""  # 例: "動物園"
     description: str = ""
     confidence: str = "HIGH"  # "HIGH" | "MEDIUM" | "LOW"
 
@@ -47,39 +51,43 @@ class EventData:
 @dataclass(frozen=True)
 class TaskData:
     """タスクデータ"""
-    title: str           # 例: "同意書の提出"
-    due_date: str        # YYYY-MM-DD: "2025-10-10"
+
+    title: str  # 例: "同意書の提出"
+    due_date: str  # YYYY-MM-DD: "2025-10-10"
     assignee: str = "PARENT"  # "PARENT" | "CHILD"
-    note: str = ""       # 例: "署名が必要です"
+    note: str = ""  # 例: "署名が必要です"
 
 
 @dataclass(frozen=True)
 class DocumentAnalysis:
     """文書解析結果"""
-    summary: str                                    # 文書要約
-    category: Category                              # EVENT | TASK | INFO | IGNORE
+
+    summary: str  # 文書要約
+    category: Category  # EVENT | TASK | INFO | IGNORE
     related_profile_ids: list[str] = field(default_factory=list)
     events: list[EventData] = field(default_factory=list)
     tasks: list[TaskData] = field(default_factory=list)
-    archive_filename: str = ""                      # 例: "20251025_遠足_長男.pdf"
+    archive_filename: str = ""  # 例: "20251025_遠足_長男.pdf"
 
 
 @dataclass(frozen=True)
 class FileInfo:
     """Google Driveファイル情報"""
-    id: str              # Google Drive file ID
-    name: str            # 元のファイル名
-    mime_type: str       # 例: "application/pdf"
+
+    id: str  # Google Drive file ID
+    name: str  # 元のファイル名
+    mime_type: str  # 例: "application/pdf"
     web_view_link: str = ""
 
 
 @dataclass(frozen=True)
 class ProcessingResult:
     """各ファイル処理の結果。テストや冪等性チェックに利用。"""
+
     file_info: FileInfo
-    analysis: Optional[DocumentAnalysis] = None
+    analysis: DocumentAnalysis | None = None
     events_created: int = 0
     tasks_created: int = 0
     notification_sent: bool = False
     archived: bool = False
-    error: Optional[str] = None
+    error: str | None = None

--- a/v2/domain/ports.py
+++ b/v2/domain/ports.py
@@ -11,13 +11,15 @@ School Agent v2では全て新規実装のアダプタなので、ABCの方が�
 """
 
 from __future__ import annotations
+
 from abc import ABC, abstractmethod
+
 from v2.domain.models import (
-    Profile,
-    Rule,
-    FileInfo,
     DocumentAnalysis,
     EventData,
+    FileInfo,
+    Profile,
+    Rule,
     TaskData,
 )
 

--- a/v2/entrypoints/cli.py
+++ b/v2/entrypoints/cli.py
@@ -10,12 +10,15 @@
 
 import logging
 import sys
+
 from v2.entrypoints.factory import create_orchestrator
+
 
 # ログ設定
 def setup_logging():
     """ログ設定を初期化"""
     import os
+
     log_level = os.getenv("LOG_LEVEL", "INFO").upper()
 
     logging.basicConfig(
@@ -23,6 +26,7 @@ def setup_logging():
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
+
 
 def main():
     """メインエントリーポイント"""
@@ -59,7 +63,9 @@ def main():
             print(f"    Category: {result.analysis.category.value}")
             print(f"    Events Created: {result.events_created}")
             print(f"    Tasks Created: {result.tasks_created}")
-            print(f"    Notification Sent: {'Yes' if result.notification_sent else 'No'}")
+            print(
+                f"    Notification Sent: {'Yes' if result.notification_sent else 'No'}"
+            )
             print(f"    Archived: {'Yes' if result.archived else 'No'}")
 
         # エラーがあったファイルがあれば終了コード1
@@ -81,6 +87,7 @@ def main():
         logger.exception("Fatal error")
         print(f"\n❌ Fatal Error: {e}")
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/v2/entrypoints/cloud_function.py
+++ b/v2/entrypoints/cloud_function.py
@@ -25,10 +25,13 @@
 """
 
 import logging
+
 import functions_framework
+
 from v2.entrypoints.factory import create_orchestrator
 
 logger = logging.getLogger(__name__)
+
 
 @functions_framework.http
 def school_agent_http(request):

--- a/v2/entrypoints/factory.py
+++ b/v2/entrypoints/factory.py
@@ -4,14 +4,15 @@
 """
 
 import logging
-from v2.config import AppConfig
+
 from v2.adapters.credentials import get_google_credentials
-from v2.adapters.google_sheets import GoogleSheetsConfigSource
-from v2.adapters.google_drive import GoogleDriveStorage
 from v2.adapters.gemini import GeminiDocumentAnalyzer
 from v2.adapters.google_calendar import GoogleCalendarService
-from v2.adapters.todoist import TodoistAdapter
+from v2.adapters.google_drive import GoogleDriveStorage
+from v2.adapters.google_sheets import GoogleSheetsConfigSource
 from v2.adapters.slack import SlackNotifier
+from v2.adapters.todoist import TodoistAdapter
+from v2.config import AppConfig
 from v2.services.action_dispatcher import ActionDispatcher
 from v2.services.orchestrator import Orchestrator
 
@@ -102,8 +103,10 @@ def create_orchestrator(config: AppConfig | None = None) -> Orchestrator:
 
 # Null Object Pattern（Todoist/Slackが無効な場合の代替）
 
+
 class _NullTaskService:
     """TaskServiceのNull Object（何もしない）"""
+
     def create_task(self, task, file_link=""):
         logger.debug("NullTaskService: task skipped (Todoist not configured)")
         return "null"
@@ -111,5 +114,6 @@ class _NullTaskService:
 
 class _NullNotifier:
     """NotifierのNull Object（何もしない）"""
+
     def notify_file_processed(self, filename, summary, events, tasks, file_link=""):
         logger.debug("NullNotifier: notification skipped (Slack not configured)")

--- a/v2/services/__init__.py
+++ b/v2/services/__init__.py
@@ -1,7 +1,7 @@
 """Services layer - ビジネスロジック"""
 
-from v2.services.orchestrator import Orchestrator
 from v2.services.action_dispatcher import ActionDispatcher, DispatchResult
+from v2.services.orchestrator import Orchestrator
 
 __all__ = [
     "Orchestrator",

--- a/v2/services/action_dispatcher.py
+++ b/v2/services/action_dispatcher.py
@@ -1,10 +1,12 @@
 """ActionDispatcher - 解析結果からアクション実行への振り分け"""
 
 from __future__ import annotations
-from dataclasses import dataclass
+
 import logging
+from dataclasses import dataclass
+
 from v2.domain.models import DocumentAnalysis, FileInfo, Profile
-from v2.domain.ports import CalendarService, TaskService, Notifier
+from v2.domain.ports import CalendarService, Notifier, TaskService
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +14,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class DispatchResult:
     """アクション実行結果"""
+
     events_created: int = 0
     tasks_created: int = 0
     notification_sent: bool = False
@@ -57,9 +60,7 @@ class ActionDispatcher:
         result = DispatchResult()
 
         # Calendar events (LOW confidence は除外)
-        eligible_events = [
-            e for e in analysis.events if e.confidence != "LOW"
-        ]
+        eligible_events = [e for e in analysis.events if e.confidence != "LOW"]
         logger.info(
             "Processing %d events (%d filtered by confidence)",
             len(eligible_events),
@@ -73,9 +74,7 @@ class ActionDispatcher:
             logger.debug(
                 "Creating event '%s' on calendar %s", event.summary, calendar_id
             )
-            self._calendar.create_event(
-                calendar_id, event, file_info.web_view_link
-            )
+            self._calendar.create_event(calendar_id, event, file_info.web_view_link)
             result.events_created += 1
 
         # Tasks

--- a/v2/services/orchestrator.py
+++ b/v2/services/orchestrator.py
@@ -5,13 +5,15 @@ Ports（Protocol）にのみ依存し、外部APIの実装詳細からは独立�
 """
 
 from __future__ import annotations
+
 import logging
+
+from v2.domain.models import FileInfo, ProcessingResult
 from v2.domain.ports import (
     ConfigSource,
-    FileStorage,
     DocumentAnalyzer,
+    FileStorage,
 )
-from v2.domain.models import FileInfo, ProcessingResult
 from v2.services.action_dispatcher import ActionDispatcher
 
 logger = logging.getLogger(__name__)
@@ -84,14 +86,10 @@ class Orchestrator:
             result = self._process_single(file_info, profiles, rules)
             results.append(result)
 
-        logger.info(
-            "=== Processing complete: %d files processed ===", len(results)
-        )
+        logger.info("=== Processing complete: %d files processed ===", len(results))
         return results
 
-    def _process_single(
-        self, file_info: FileInfo, profiles, rules
-    ) -> ProcessingResult:
+    def _process_single(self, file_info: FileInfo, profiles, rules) -> ProcessingResult:
         """
         1ファイルの処理。エラーが発生しても他のファイル処理は続行。
 
@@ -118,9 +116,7 @@ class Orchestrator:
             logger.info("Analysis complete: %s", analysis.summary)
 
             # アクション実行
-            dispatch_result = self._dispatcher.dispatch(
-                file_info, analysis, profiles
-            )
+            dispatch_result = self._dispatcher.dispatch(file_info, analysis, profiles)
 
             # アーカイブ
             archive_name = analysis.archive_filename or f"PROCESSED_{file_info.name}"


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml` を新規作成。main向けPRで自動実行される lint/test の2並列ジョブを構成
- `pyproject.toml` に `[tool.ruff]` 設定を追加（target-version=py313、E501除外）
- `v2/` 全ファイルに ruff auto-fix を適用（import整序、型アノテーション現代化、未使用変数除去）

## CI構成

| ジョブ | 内容 |
|--------|------|
| `lint` | `ruff check v2/` + `ruff format --check v2/` |
| `test` | `pytest tests/unit/ tests/integration/ -m "not manual" --cov=v2` |

- トリガー: `v2/**`, `tests/**`, `pyproject.toml`, `uv.lock`, `.github/workflows/ci.yml` の変更を含むPR
- `tests/` は lint 対象外（e2e/manual を含む都合上）
- `tests/manual/` および `@pytest.mark.manual` テストはCI除外済み

## Test plan

- [ ] PRを作成し、GitHub Actions の lint / test ジョブが両方グリーンになることを確認
- [ ] `v2/` に意図的な ruff 違反を追加し lint ジョブが失敗することを確認（任意）
- [ ] 失敗するユニットテストを追加し test ジョブが失敗することを確認（任意）

🤖 Generated with [Claude Code](https://claude.com/claude-code)