### PR TITLE
feat: コンテナベースデプロイ基盤を導入（Artifact Registry + build_push.sh）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ sample/
 # Terraform provider cache
 terraform/.terraform/
 terraform/environments/**/.terraform/
+terraform/**/terraform.tfstate
+terraform/**/terraform.tfstate.backup
+terraform/**/terraform.tfvars

--- a/build_push.sh
+++ b/build_push.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+# ==========================================
+# Configuration
+# ==========================================
+REGION="asia-northeast1"
+IMAGE_NAME="school-agent-v2"
+
+# 引数: ENV（dev/prod）, IMAGE_TAG（任意）
+ENV="${1:-dev}"
+IMAGE_TAG="${2:-$(git rev-parse --short HEAD 2>/dev/null || echo 'latest')}"
+
+# 環境ごとのリポジトリID
+case "$ENV" in
+  dev)  REPOSITORY_ID="school-agent-dev" ;;
+  prod) REPOSITORY_ID="school-agent" ;;
+  *)    echo "Error: Unknown environment '$ENV'. Use 'dev' or 'prod'."; exit 1 ;;
+esac
+
+# Load environment variables
+if [ -f .env ]; then
+  export $(cat .env | grep -v '#' | awk '/=/ {print $1}')
+fi
+
+# Check required
+if [ -z "${PROJECT_ID:-}" ]; then
+  echo "Error: PROJECT_ID is not set in .env"
+  exit 1
+fi
+
+IMAGE_URL="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPOSITORY_ID}/${IMAGE_NAME}:${IMAGE_TAG}"
+
+echo "Environment : ${ENV}"
+echo "Image URL   : ${IMAGE_URL}"
+
+# ==========================================
+# Preparation
+# ==========================================
+echo "Generating requirements.txt..."
+uv export -o requirements.txt --no-hashes
+
+# ==========================================
+# Build
+# ==========================================
+echo "Building Docker image..."
+docker build -t "${IMAGE_URL}" .
+
+# ==========================================
+# Push
+# ==========================================
+echo "Configuring Docker auth for Artifact Registry..."
+gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+
+echo "Pushing image..."
+docker push "${IMAGE_URL}"
+
+echo ""
+echo "Successfully pushed: ${IMAGE_URL}"
+# 後続の処理から参照できるようにexportで出力
+echo "IMAGE_URL=${IMAGE_URL}"

--- a/docs/review/container-deploy-artifact-registry.md
+++ b/docs/review/container-deploy-artifact-registry.md
@@ -1,0 +1,108 @@
+# レビューレポート: container-deploy-artifact-registry
+
+**日付**: 2026-02-22
+**レビュアー**: /reviewer skill
+**仕様書**: `docs/plan/container-deploy-artifact-registry.md`
+
+---
+
+## 全体ステータス
+
+**✅ PASS**
+
+---
+
+## 要件カバレッジ
+
+### Step 1: Terraform module — Artifact Registry
+
+| チェック項目 | 結果 |
+|---|---|
+| `terraform/modules/artifact_registry/variables.tf` が新規作成されている | ✅ |
+| 変数 `project_id`, `region`, `repository_id`, `environment` が定義されている | ✅ |
+| `terraform/modules/artifact_registry/main.tf` が新規作成されている | ✅ |
+| `google_artifact_registry_repository` リソースが `format = "DOCKER"` で定義されている | ✅ |
+| `labels` に `environment` と `managed_by = "terraform"` が設定されている | ✅ |
+| `terraform/modules/artifact_registry/outputs.tf` が新規作成されている | ✅ |
+| `registry_url` 出力が `{region}-docker.pkg.dev/{project_id}/{repository_id}` 形式 | ✅ |
+| `image_base` 出力が `{registry_url}/school-agent-v2` 形式 | ✅ |
+
+### Step 2: Terraform dev 環境
+
+| チェック項目 | 結果 |
+|---|---|
+| `terraform/environments/dev/variables.tf` が新規作成されている | ✅ |
+| `region` のデフォルト値が `"asia-northeast1"` | ✅ |
+| `terraform/environments/dev/main.tf` が新規作成されている | ✅ |
+| `required_version = ">= 1.5"` が設定されている | ✅ |
+| `google ~> 6.0` プロバイダが指定されている | ✅ |
+| GCS バックエンド設定がコメントアウトで残されている | ✅ |
+| `module "artifact_registry"` が `source = "../../modules/artifact_registry"` で呼び出されている | ✅ |
+| `repository_id = "school-agent-dev"`, `environment = "dev"` が渡されている | ✅ |
+| `terraform/environments/dev/outputs.tf` が新規作成されている | ✅ |
+| `registry_url`, `image_base` がモジュール出力のパススルーとして定義されている | ✅ |
+
+### Step 3: build_push.sh
+
+| チェック項目 | 結果 |
+|---|---|
+| プロジェクトルートに `build_push.sh` が新規作成されている | ✅ |
+| `chmod +x` で実行権限が付与されている (`-rwxr-xr-x`) | ✅ |
+| `set -euo pipefail` が冒頭に設定されている | ✅ |
+| 引数 `ENV`（default=`dev`）が実装されている | ✅ |
+| 引数 `IMAGE_TAG`（default=git short SHA, fallback=`latest`）が実装されている | ✅ |
+| `dev` → `school-agent-dev`, `prod` → `school-agent` の case 分岐がある | ✅ |
+| 不明な ENV 値で `exit 1` するバリデーションがある | ✅ |
+| `.env` から `PROJECT_ID` を読み込む（`deploy_v2.sh` と同じ方式） | ✅ |
+| `PROJECT_ID` 未設定時に `exit 1` するチェックがある | ✅ |
+| `uv export -o requirements.txt --no-hashes` が実行される | ✅ |
+| `docker build -t "${IMAGE_URL}" .` が実行される | ✅ |
+| `gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet` が実行される | ✅ |
+| `docker push "${IMAGE_URL}"` が実行される | ✅ |
+| 最終行に `IMAGE_URL=${IMAGE_URL}` が標準出力される | ✅ |
+
+### Step 4: .gitignore 更新
+
+| チェック項目 | 結果 |
+|---|---|
+| `terraform/**/terraform.tfstate` が追加されている | ✅ |
+| `terraform/**/terraform.tfstate.backup` が追加されている | ✅ |
+| `terraform/**/terraform.tfvars` が追加されている | ✅ |
+| `terraform/**/.terraform/` は既存エントリ（`terraform/environments/**/.terraform/`）が存在するためスキップ | ✅（仕様通り） |
+
+---
+
+## テスト・静的解析結果
+
+### terraform validate
+
+```
+$ cd terraform/environments/dev && terraform validate
+Success! The configuration is valid.
+```
+
+**結果**: ✅ PASS
+
+### build_push.sh 構文チェック
+
+```
+$ bash -n build_push.sh
+syntax OK
+```
+
+**結果**: ✅ PASS
+
+### 実行権限確認
+
+```
+$ ls -la build_push.sh
+-rwxr-xr-x@ 1 masahiro  staff  1701  2 22 14:58 build_push.sh
+```
+
+**結果**: ✅ PASS
+
+---
+
+## 修正指示
+
+なし（全要件を満たしており、テスト・静的解析もすべて PASS）。

--- a/terraform/environments/dev/.terraform.lock.hcl
+++ b/terraform/environments/dev/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:79CwMTsp3Ud1nOl5hFS5mxQHyT0fGVye7pqpU0PPlHI=",
+    "zh:1f3513fcfcbf7ca53d667a168c5067a4dd91a4d4cccd19743e248ff31065503c",
+    "zh:3da7db8fc2c51a77dd958ea8baaa05c29cd7f829bd8941c26e2ea9cb3aadc1e5",
+    "zh:3e09ac3f6ca8111cbb659d38c251771829f4347ab159a12db195e211c76068bb",
+    "zh:7bb9e41c568df15ccf1a8946037355eefb4dfb4e35e3b190808bb7c4abae547d",
+    "zh:81e5d78bdec7778e6d67b5c3544777505db40a826b6eb5abe9b86d4ba396866b",
+    "zh:8d309d020fb321525883f5c4ea864df3d5942b6087f6656d6d8b3a1377f340fc",
+    "zh:93e112559655ab95a523193158f4a4ac0f2bfed7eeaa712010b85ebb551d5071",
+    "zh:d3efe589ffd625b300cef5917c4629513f77e3a7b111c9df65075f76a46a63c7",
+    "zh:d4a4d672bbef756a870d8f32b35925f8ce2ef4f6bbd5b71a3cb764f1b6c85421",
+    "zh:e13a86bca299ba8a118e80d5f84fbdd708fe600ecdceea1a13d4919c068379fe",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
+  ]
+}

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+  # 将来的にGCSバックエンドへ移行する（別タスク）
+  # backend "gcs" {
+  #   bucket = "YOUR_TFSTATE_BUCKET"
+  #   prefix = "terraform/environments/dev"
+  # }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+module "artifact_registry" {
+  source = "../../modules/artifact_registry"
+
+  project_id    = var.project_id
+  region        = var.region
+  repository_id = "school-agent-dev"
+  environment   = "dev"
+}

--- a/terraform/environments/dev/outputs.tf
+++ b/terraform/environments/dev/outputs.tf
@@ -1,0 +1,9 @@
+output "registry_url" {
+  description = "dev 環境の Artifact Registry URL"
+  value       = module.artifact_registry.registry_url
+}
+
+output "image_base" {
+  description = "dev 環境のイメージ名ベース"
+  value       = module.artifact_registry.image_base
+}

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -1,0 +1,10 @@
+variable "project_id" {
+  description = "dev 環境の GCP プロジェクトID"
+  type        = string
+}
+
+variable "region" {
+  description = "デプロイリージョン"
+  type        = string
+  default     = "asia-northeast1"
+}

--- a/terraform/modules/artifact_registry/main.tf
+++ b/terraform/modules/artifact_registry/main.tf
@@ -1,0 +1,12 @@
+resource "google_artifact_registry_repository" "this" {
+  project       = var.project_id
+  location      = var.region
+  repository_id = var.repository_id
+  format        = "DOCKER"
+  description   = "school-agent コンテナイメージリポジトリ (${var.environment})"
+
+  labels = {
+    environment = var.environment
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/modules/artifact_registry/outputs.tf
+++ b/terraform/modules/artifact_registry/outputs.tf
@@ -1,0 +1,9 @@
+output "registry_url" {
+  description = "Artifact Registry の Docker リポジトリ URL"
+  value       = "${var.region}-docker.pkg.dev/${var.project_id}/${var.repository_id}"
+}
+
+output "image_base" {
+  description = "イメージ名のベース（タグなし）"
+  value       = "${var.region}-docker.pkg.dev/${var.project_id}/${var.repository_id}/school-agent-v2"
+}

--- a/terraform/modules/artifact_registry/variables.tf
+++ b/terraform/modules/artifact_registry/variables.tf
@@ -1,0 +1,19 @@
+variable "project_id" {
+  description = "GCP プロジェクトID"
+  type        = string
+}
+
+variable "region" {
+  description = "Artifact Registry のロケーション"
+  type        = string
+}
+
+variable "repository_id" {
+  description = "Artifact Registry リポジトリID"
+  type        = string
+}
+
+variable "environment" {
+  description = "環境名（ラベル用）"
+  type        = string
+}


### PR DESCRIPTION
## Summary

- Artifact Registry を管理する Terraform module (`terraform/modules/artifact_registry/`) を新規作成
- dev 環境の Terraform エントリポイント (`terraform/environments/dev/`) を新規作成（`terraform init` + `validate` 済み）
- コンテナ build & Artifact Registry push スクリプト `build_push.sh` を新規作成（`bash -n` 構文チェック済み）
- `.gitignore` に `terraform/**/terraform.tfstate`, `.tfstate.backup`, `.tfvars` を追加

## Test plan

- [x] `terraform validate` — `Success! The configuration is valid.`
- [x] `bash -n build_push.sh` — syntax OK
- [x] `build_push.sh` に実行権限 (`-rwxr-xr-x`) が付与されていることを確認
- [x] 実環境での `terraform apply` および `./build_push.sh dev` は別タスクで実施

## Related

仕様書: `docs/plan/container-deploy-artifact-registry.md`
レビューレポート: `docs/review/container-deploy-artifact-registry.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)