### PR TITLE
feat: prod 環境デプロイ基盤を追加

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -1,0 +1,178 @@
+name: CD (prod)
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      target_tag:
+        description: 'ロールバック先の release tag (例: v1.0.0)。指定した場合はそのタグのイメージを再デプロイします（再ビルドなし）。'
+        required: true
+
+permissions:
+  contents: read
+  id-token: write  # WIF OIDC トークン発行に必要
+
+env:
+  PROJECT_ID: marufeuille-linebot
+  REGION: asia-northeast1
+  REPOSITORY_ID: school-agent-prod
+  IMAGE_NAME: school-agent-v2
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Ruff lint
+        run: uv run ruff check v2/
+
+      - name: Ruff format check
+        run: uv run ruff format --check v2/
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run tests
+        run: >
+          uv run pytest
+          tests/unit/
+          tests/integration/
+          -m "not manual"
+          --cov=v2
+          --cov-report=term-missing
+
+  deploy:
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    environment: prod
+    concurrency:
+      group: deploy-prod
+      cancel-in-progress: false  # デプロイ途中でキャンセルしない
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to GCP via Workload Identity Federation
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+
+      # ---------------------------------------------------------------------------
+      # 通常デプロイ (tag push): ビルド → SHA タグ + release タグを push
+      # prod-latest は Terraform apply 成功後に更新する
+      # ---------------------------------------------------------------------------
+
+      - name: Set up uv
+        if: github.event_name == 'push'
+        uses: astral-sh/setup-uv@v5
+
+      - name: Export requirements.txt
+        if: github.event_name == 'push'
+        run: uv export -o requirements.txt --no-hashes
+
+      - name: Build and push Docker image (normal deploy)
+        if: github.event_name == 'push'
+        run: |
+          IMAGE_TAG="${GITHUB_SHA::7}"
+          RELEASE_TAG="${GITHUB_REF_NAME}"
+
+          SHA_URL="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY_ID }}/${{ env.IMAGE_NAME }}:${IMAGE_TAG}"
+          RELEASE_URL="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY_ID }}/${{ env.IMAGE_NAME }}:${RELEASE_TAG}"
+
+          docker build --platform linux/amd64 -t "${SHA_URL}" .
+          docker tag "${SHA_URL}" "${RELEASE_URL}"
+
+          # SHA タグと release タグを push（prod-latest は Terraform apply 成功後に更新）
+          docker push "${SHA_URL}"
+          docker push "${RELEASE_URL}"
+
+          # Terraform には SHA タグの URL を渡す（毎回異なるため差分を確実に検出）
+          echo "SHA_URL=${SHA_URL}" >> $GITHUB_ENV
+
+      # ---------------------------------------------------------------------------
+      # ロールバック (workflow_dispatch): 既存イメージを再デプロイ（ビルドなし）
+      # ---------------------------------------------------------------------------
+
+      - name: Resolve rollback image (rollback deploy)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          TARGET_TAG="${{ github.event.inputs.target_tag }}"
+          SHA_URL="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY_ID }}/${{ env.IMAGE_NAME }}:${TARGET_TAG}"
+
+          # ロールバック先イメージの存在確認
+          if ! gcloud artifacts docker images describe "${SHA_URL}" --quiet 2>/dev/null; then
+            echo "ERROR: イメージ ${SHA_URL} が Artifact Registry に存在しません" >&2
+            exit 1
+          fi
+
+          # ロールバック時は prod-latest を更新しない（現状の prod-latest を維持）
+          echo "SHA_URL=${SHA_URL}" >> $GITHUB_ENV
+
+      # ---------------------------------------------------------------------------
+      # Terraform apply (通常デプロイ・ロールバック共通)
+      # ---------------------------------------------------------------------------
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~> 1.5"
+
+      - name: Terraform Init
+        working-directory: terraform/environments/prod
+        run: terraform init
+
+      - name: Terraform Apply
+        working-directory: terraform/environments/prod
+        run: |
+          terraform apply -auto-approve \
+            -var="image_url=${SHA_URL}" \
+            -var="project_id=${{ env.PROJECT_ID }}" \
+            -var="spreadsheet_id=${{ secrets.TF_VAR_SPREADSHEET_ID }}" \
+            -var="inbox_folder_id=${{ secrets.TF_VAR_INBOX_FOLDER_ID }}" \
+            -var="archive_folder_id=${{ secrets.TF_VAR_ARCHIVE_FOLDER_ID }}"
+
+      # ---------------------------------------------------------------------------
+      # Terraform apply 成功後にのみ prod-latest を更新
+      # ロールバック時は prod-latest を更新しない（現在 prod で動いているイメージを指し続ける）
+      # ---------------------------------------------------------------------------
+
+      - name: Update prod-latest tag after successful deploy
+        if: github.event_name == 'push'
+        run: |
+          PROD_LATEST_URL="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY_ID }}/${{ env.IMAGE_NAME }}:prod-latest"
+          docker tag "${SHA_URL}" "${PROD_LATEST_URL}"
+          docker push "${PROD_LATEST_URL}"

--- a/docs/plan/prod-deploy.md
+++ b/docs/plan/prod-deploy.md
@@ -1,0 +1,407 @@
+# prod 環境デプロイ計画
+
+## 目標
+
+GitHub の tag push (`v*`) をトリガーとして、GitHub Actions 経由で prod 環境へ自動デプロイする仕組みを構築する。
+既存の手動デプロイ済み prod 環境は、新環境が正常稼働後に削除する。
+
+---
+
+## 現状確認
+
+| 項目 | dev 環境 (現状) | prod 環境 (今回構築) |
+|------|----------------|---------------------|
+| トリガー | `main` ブランチ push | GitHub tag push (`v*`) |
+| イメージタグ (Terraform) | `:latest` | `:<sha7>` (+ `prod-latest` エイリアス) |
+| Artifact Registry | `school-agent-dev` | `school-agent-prod` (新規) |
+| WIF | `github-actions` pool + `github-actions-deploy` SA | 同 pool を参照、`github-actions-deploy-prod` SA を新規作成 |
+| GCP プロジェクト | `marufeuille-linebot` | 同一プロジェクト (現状に合わせる) |
+
+---
+
+## イメージタグ戦略の決定
+
+### dev vs prod の問題
+
+dev は `latest` タグを使うため、`main` push のたびに `latest` が更新される。
+GCP Cloud Run Jobs は **Job 更新時点のイメージダイジェストを内部的に固定する**仕様のため、
+`prod-latest` のような可変タグを Terraform の `image_url` にしても、タグが更新されるだけでは
+Job 定義が変わらず、Terraform apply が no-op になり新イメージが反映されない。
+
+### 採用方針
+
+- Terraform `image_url` には **`<sha7>` タグ** を使用する
+  → 毎回異なる URL になるため Terraform が差分を検出し Cloud Run Job を更新する
+- **`prod-latest` タグも同時に push** する
+  → オペレーター参照・ロールバック確認用の安定したエイリアスとして機能する
+  → このタグは GitHub tag push 時のみ更新されるため、dev の `latest` とは明確に区別できる
+
+```
+asia-northeast1-docker.pkg.dev/marufeuille-linebot/school-agent-prod/school-agent-v2:<sha7>   ← Terraform が参照
+asia-northeast1-docker.pkg.dev/marufeuille-linebot/school-agent-prod/school-agent-v2:prod-latest  ← エイリアス
+asia-northeast1-docker.pkg.dev/marufeuille-linebot/school-agent-prod/school-agent-v2:v1.2.3  ← GitHub tag 名と同一
+```
+
+---
+
+## Terraform 構成
+
+### ディレクトリ構造
+
+```
+terraform/
+├── environments/
+│   ├── dev/          # 既存 (変更なし)
+│   └── prod/         # 新規作成
+│       ├── main.tf
+│       ├── variables.tf
+│       ├── outputs.tf
+│       └── terraform.tfvars
+└── modules/          # 既存モジュールを流用 (変更なし)
+```
+
+### backend 設定
+
+```hcl
+backend "gcs" {
+  bucket = "marufeuille-linebot-terraform-backend"
+  prefix = "terraform/environments/prod"
+}
+```
+
+既存の dev と同一バケットの別 prefix を使用する。
+
+### 作成リソース一覧
+
+| リソース種別 | リソース名 | 備考 |
+|-------------|-----------|------|
+| Service Account | `school-agent-v2-prod` | Cloud Run Job 実行用 |
+| IAM binding | `roles/aiplatform.user` → 上記 SA | Vertex AI 呼び出し権限 |
+| IAM binding | `roles/iam.serviceAccountTokenCreator` → Cloud Scheduler SA | スケジューラー呼び出し権限 |
+| Artifact Registry | `school-agent-prod` | prod 専用リポジトリ |
+| Secret Manager | `school-agent-slack-bot-token-prod` | |
+| Secret Manager | `school-agent-slack-channel-id-prod` | |
+| Secret Manager | `school-agent-todoist-api-token-prod` | |
+| Cloud Run Job | `school-agent-v2-prod` | |
+| Cloud Scheduler | `school-agent-v2-scheduler-prod` | スケジュールは dev と同じ `0 9,17 * * *` を初期値に |
+| Service Account | `github-actions-deploy-prod` | GitHub Actions デプロイ用 |
+| WIF binding | 既存 pool への SA バインド | pool/provider は dev Terraform 管理のものを ID 指定で参照 |
+| IAM bindings | 各種権限 → `github-actions-deploy-prod` SA | 下記参照 |
+
+### GitHub Actions SA に付与する IAM ロール (prod)
+
+dev と同一セットを prod スコープで付与:
+
+```
+roles/artifactregistry.writer          # Docker push
+roles/run.developer                    # Cloud Run Job 更新
+roles/iam.serviceAccountUser           # Cloud Run SA として実行
+roles/storage.admin                    # Terraform state (GCS)
+roles/cloudscheduler.admin             # Cloud Scheduler 管理
+roles/resourcemanager.projectIamAdmin  # IAM ポリシー変更
+roles/secretmanager.admin              # Secret Manager 管理
+roles/serviceusage.serviceUsageAdmin   # API 有効化
+roles/iam.serviceAccountAdmin          # SA 作成・管理
+```
+
+### WIF の取り扱い
+
+WIF Pool・Provider は dev Terraform で管理済みのため、prod Terraform では新規作成しない。
+prod SA (`github-actions-deploy-prod`) を既存 pool に WIF バインドする:
+
+```hcl
+resource "google_service_account_iam_member" "wif_binding_prod" {
+  service_account_id = google_service_account.github_actions_prod.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/github-actions/attribute.repository/marufeuille/ClearBag"
+}
+```
+
+`<PROJECT_NUMBER>` は `data "google_project"` で動的取得する。
+
+---
+
+## GitHub Actions ワークフロー
+
+### ファイル: `.github/workflows/cd-prod.yml`
+
+```
+on:
+  push:
+    tags:
+      - 'v*'
+```
+
+#### ジョブ構成
+
+1. **lint** - dev と同じ ruff lint チェック
+2. **test** - dev と同じ pytest 実行
+3. **deploy** (needs: [lint, test])
+   - Environment: `prod`
+   - concurrency: `deploy-prod`
+   - 手順:
+     1. WIF 認証 (prod secrets: `WIF_PROVIDER`, `WIF_SERVICE_ACCOUNT`)
+     2. Docker 認証
+     3. `uv export` で requirements.txt 生成
+     4. イメージビルド
+        - `IMAGE_TAG = "${GITHUB_SHA::7}"`  (SHA タグ)
+        - `RELEASE_TAG = "${GITHUB_REF_NAME}"` (例: `v1.2.3`)
+        - SHA URL: `<registry>/school-agent-prod/school-agent-v2:<sha7>`
+        - `prod-latest` URL: `<registry>/school-agent-prod/school-agent-v2:prod-latest`
+        - Release tag URL: `<registry>/school-agent-prod/school-agent-v2:<v1.2.3>`
+     5. 3タグすべて push
+     6. Terraform init / apply
+        - `working-directory: terraform/environments/prod`
+        - `-var="image_url=${SHA_URL}"` ← SHA タグで固定
+
+#### Terraform apply に渡す変数
+
+| 変数名 | 設定方法 |
+|--------|---------|
+| `project_id` | ワークフロー env または secrets |
+| `image_url` | ビルド時の SHA URL を `$GITHUB_ENV` 経由で渡す |
+| `spreadsheet_id` | GitHub Environment Secret: `TF_VAR_SPREADSHEET_ID` |
+| `inbox_folder_id` | GitHub Environment Secret: `TF_VAR_INBOX_FOLDER_ID` |
+| `archive_folder_id` | GitHub Environment Secret: `TF_VAR_ARCHIVE_FOLDER_ID` |
+
+---
+
+## GitHub 設定 (手動作業)
+
+### Environment `prod` の作成
+
+GitHub リポジトリ Settings → Environments → New environment で `prod` を作成し、
+以下の Secrets を設定する:
+
+| Secret 名 | 内容 |
+|-----------|------|
+| `WIF_PROVIDER` | Terraform apply 後に出力される prod SA の WIF Provider パス |
+| `WIF_SERVICE_ACCOUNT` | `github-actions-deploy-prod` SA のメールアドレス |
+| `TF_VAR_SPREADSHEET_ID` | prod 用 Google スプレッドシート ID |
+| `TF_VAR_INBOX_FOLDER_ID` | prod 用 受信フォルダ ID |
+| `TF_VAR_ARCHIVE_FOLDER_ID` | prod 用 アーカイブフォルダ ID |
+
+> オプション: Environment の Protection rules で「Required reviewers」を設定すると、
+> tag push 後に手動承認が必要になり誤デプロイを防止できる。
+
+### Secret Manager への値の手動投入
+
+Terraform は Secret のリソース（シェル）を作成するが、値は別途投入が必要:
+
+```bash
+echo -n "<SLACK_BOT_TOKEN>" | gcloud secrets versions add school-agent-slack-bot-token-prod --data-file=-
+echo -n "<SLACK_CHANNEL_ID>" | gcloud secrets versions add school-agent-slack-channel-id-prod --data-file=-
+echo -n "<TODOIST_API_TOKEN>" | gcloud secrets versions add school-agent-todoist-api-token-prod --data-file=-
+```
+
+---
+
+## デプロイ手順
+
+### Phase 1: Terraform prod 環境の初期構築
+
+```
+前提: terraform/environments/prod/ ファイルを作成済み
+```
+
+1. 初回は GitHub Actions を使わず、ローカルから初期化のみ実施
+   ```bash
+   cd terraform/environments/prod
+   terraform init
+   # (plan で確認後)
+   terraform apply -var="image_url=dummy" -var="project_id=..." ...
+   ```
+   ※ `image_url=dummy` で一旦インフラだけ構築。Cloud Run Job は後で正しいイメージで上書き。
+
+   **または**: 初回デプロイは tag を push して Actions 経由で実施 (推奨)
+   → Artifact Registry や Secret Manager 等がないと Actions が失敗するため、
+     先に Terraform で `exclude_resources = [cloud_run_job, cloud_scheduler]` 的に部分 apply するか、
+     Actions の deploy ジョブを 2 段階に分けることを検討する
+
+2. Terraform outputs から WIF 情報を取得し、GitHub Environment Secrets に設定
+3. Secret Manager に値を投入
+
+### Phase 2: 初回 prod リリース
+
+1. Secret Manager に prod の各シークレット値を投入 (上記コマンド)
+2. main ブランチで動作確認完了後、tag を打つ:
+   ```bash
+   git tag v1.0.0
+   git push origin v1.0.0
+   ```
+3. GitHub Actions `cd-prod.yml` が起動 → テスト → イメージビルド → Terraform apply
+4. Cloud Run Job が正常に実行されることを確認
+
+### Phase 3: 既存手動デプロイの削除
+
+新環境が正常稼働していることを確認後、手動デプロイで作成したリソースを削除:
+
+```bash
+# 手動でデプロイされた Cloud Run Job (名前を確認の上)
+gcloud run jobs delete <OLD_PROD_JOB_NAME> --region=asia-northeast1
+
+# 手動でデプロイされた Cloud Scheduler (あれば)
+gcloud scheduler jobs delete <OLD_PROD_SCHEDULER_NAME> --location=asia-northeast1
+
+# 手動で作成した Service Account (あれば、かつ Terraform 管理外であれば)
+# gcloud iam service-accounts delete <OLD_SA_EMAIL>
+```
+
+> Terraform 管理対象のリソースは `terraform destroy` を使わないこと。
+
+---
+
+## ロールバック戦略
+
+### 前提: ロールバックが可能な理由
+
+Terraform `image_url` に SHA タグを使っているため、以下が担保される:
+
+- Artifact Registry に各バージョンのイメージが残る (`v1.0.0`, `v1.1.0` など)
+- Terraform state に「どの SHA で何の Job が動いているか」が記録される
+- 過去の SHA URL を Terraform apply に渡せば、任意のバージョンに戻せる
+
+**Artifact Registry のクリーンアップポリシーに注意**: ロールバック用イメージが自動削除されないよう、
+prod リポジトリではクリーンアップポリシーを設定しないか、最低でも過去 N バージョンを保持する設定にする。
+
+---
+
+### ロールバック手順
+
+#### 方法1: GitHub Actions の workflow_dispatch でロールバック（推奨）
+
+`cd-prod.yml` に `workflow_dispatch` トリガーと `target_tag` 入力を追加する:
+
+```yaml
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      target_tag:
+        description: 'ロールバック先の release tag (例: v1.0.0)'
+        required: true
+```
+
+ロールバック時の操作:
+```
+GitHub Actions → Run workflow → target_tag に "v1.0.0" を入力 → 実行
+```
+
+ワークフロー内では:
+- `target_tag` 入力がある場合: `git checkout <target_tag>` してそのコードをビルド
+- ただし、**イメージはすでに Artifact Registry に存在**するため、再ビルドしない
+  → Artifact Registry に `v1.0.0` タグのイメージが存在すれば、それを Terraform に渡すだけで良い
+
+```yaml
+- name: Resolve rollback image
+  if: github.event_name == 'workflow_dispatch'
+  run: |
+    TARGET_TAG="${{ github.event.inputs.target_tag }}"
+    SHA_URL="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPOSITORY_ID}/${IMAGE_NAME}:${TARGET_TAG}"
+    echo "SHA_URL=${SHA_URL}" >> $GITHUB_ENV
+    # prod-latest は更新しない（ロールバック中は現在の prod-latest を維持）
+```
+
+**メリット**: Terraform state と実際のリソースが一致したまま
+
+---
+
+#### 方法2: 緊急ロールバック（手動 gcloud）
+
+デプロイパイプラインが壊れていて Actions が使えない緊急時:
+
+```bash
+# ロールバック先のイメージ URL を確認 (例: v1.0.0 タグ)
+ROLLBACK_URL="asia-northeast1-docker.pkg.dev/marufeuille-linebot/school-agent-prod/school-agent-v2:v1.0.0"
+
+# Cloud Run Job を直接更新
+gcloud run jobs update school-agent-v2-prod \
+  --image="${ROLLBACK_URL}" \
+  --region=asia-northeast1
+```
+
+**注意**: この操作は Terraform state と実際のリソースを乖離させる。
+次回 `terraform apply` 時に最新の Terraform 設定（最後に apply した SHA）に上書きされるため、
+緊急ロールバック後は必ず方法1でロールバックを Terraform 管理下に戻すこと。
+
+---
+
+#### 方法3: 旧バージョンタグで新 release tag を切る（コードレベルでのロールバック）
+
+v1.1.0 で問題が発生し、v1.0.0 のコードに戻したい場合:
+
+```bash
+git checkout v1.0.0
+git checkout -b hotfix/rollback-to-v1.0.0
+# 必要であれば最小限の修正を加えて
+git tag v1.1.1
+git push origin v1.1.1
+```
+
+`cd-prod.yml` が起動し、v1.0.0 相当のコードで `v1.1.1` イメージをビルドしてデプロイ。
+コードとリリース履歴が明示的に残る。
+
+---
+
+### ロールバック判断基準
+
+Cloud Run Jobs は定時実行 (Scheduler) のため、デプロイ直後に次の定時実行が来るまで問題に気づかない可能性がある。
+
+| 問題の種類 | 確認方法 | 対応 |
+|-----------|---------|------|
+| Job がクラッシュする | Cloud Logging でエラー確認 | 方法1 または 方法2 |
+| Job は成功するが出力が不正 | Slack 通知・スプレッドシートの確認 | 方法1 |
+| Actions パイプラインが壊れている | GitHub Actions のログ確認 | 方法2 |
+| コードレベルの問題 | テスト・ログ解析 | 方法3 |
+
+---
+
+### prod-latest タグのロールバック時の扱い
+
+- **通常デプロイ時**: `prod-latest` を最新 SHA に更新する
+- **ロールバック時 (方法1・2)**: `prod-latest` は**更新しない**
+  → ロールバック中であることを明示するため、`prod-latest` が最新リリースを指さない状態を許容する
+  → または `prod-latest` もロールバック先の SHA に戻すことで「現在動いているイメージ = prod-latest」を維持する
+
+設計判断: `prod-latest` は「現在 prod で動いているイメージ」を常に指すようにするのが望ましい。
+ワークフローでは Terraform apply 成功後に `prod-latest` を更新するステップを配置する。
+
+---
+
+## 考慮事項・制約
+
+### 同一 GCP プロジェクトを共有
+
+dev と prod が同一プロジェクト (`marufeuille-linebot`) を使用するため:
+- WIF Pool/Provider は共有 (dev Terraform 管理)
+- prod Terraform が WIF Pool を削除・変更しないよう、pool は data source か参照のみで扱う
+- 将来的にプロジェクト分離を検討する場合は Terraform module の project_id を変えるだけで対応可能
+
+### 初回 Terraform apply の課題
+
+Cloud Run Job の image_url に有効なイメージが必要なため、以下のいずれかで対応:
+1. **Actions 経由**: Terraform plan のみ先行し、イメージ push 後に apply (推奨)
+2. **ローカル先行**: インフラ部分 (AR, SA, Secrets) を先に apply → tag push で Cloud Run Job 含めて apply
+
+### Cloud Run Job のイメージ更新確認
+
+tag push → Actions → terraform apply が成功したら:
+```bash
+gcloud run jobs describe school-agent-v2-prod --region=asia-northeast1 --format="get(template.template.containers[0].image)"
+```
+で SHA タグが反映されているか確認する。
+
+---
+
+## ファイル変更サマリー
+
+| ファイル | 操作 |
+|---------|------|
+| `terraform/environments/prod/main.tf` | 新規作成 |
+| `terraform/environments/prod/variables.tf` | 新規作成 |
+| `terraform/environments/prod/outputs.tf` | 新規作成 |
+| `terraform/environments/prod/terraform.tfvars` | 新規作成 (非シークレット値のみ) |
+| `.github/workflows/cd-prod.yml` | 新規作成 |
+| `terraform/environments/dev/` | 変更なし |
+| `terraform/modules/` | 変更なし |

--- a/docs/review/prod-deploy.md
+++ b/docs/review/prod-deploy.md
@@ -1,0 +1,131 @@
+# レビューレポート: prod-deploy
+
+## 全体ステータス
+
+**PASS**
+
+---
+
+## 要件カバレッジ
+
+### Terraform ファイル
+
+| 要件 | 状態 | 備考 |
+|------|------|------|
+| `terraform/environments/prod/main.tf` 新規作成 | ✅ | |
+| `terraform/environments/prod/variables.tf` 新規作成 | ✅ | |
+| `terraform/environments/prod/outputs.tf` 新規作成 | ✅ | |
+| `terraform/environments/prod/terraform.tfvars` 新規作成 | ✅ | |
+| GCS backend (`prefix = "terraform/environments/prod"`) | ✅ | |
+| `terraform/environments/dev/` 変更なし | ✅ | |
+
+### 作成リソース
+
+| 要件リソース | リソース名 | 状態 |
+|-------------|-----------|------|
+| Cloud Run 実行 SA | `school-agent-v2-prod` | ✅ |
+| IAM: `roles/aiplatform.user` → 実行 SA | — | ✅ |
+| IAM: `roles/iam.serviceAccountTokenCreator` → Scheduler SA | — | ✅ |
+| Artifact Registry (prod 専用) | `school-agent-prod` | ✅ |
+| Secret Manager: slack-bot-token | `school-agent-slack-bot-token-prod` | ✅ |
+| Secret Manager: slack-channel-id | `school-agent-slack-channel-id-prod` | ✅ |
+| Secret Manager: todoist-api-token | `school-agent-todoist-api-token-prod` | ✅ |
+| Cloud Run Job | `school-agent-v2-prod` | ✅ |
+| Cloud Scheduler (`0 9,17 * * *`) | `school-agent-v2-scheduler-prod` | ✅ |
+| GitHub Actions デプロイ用 SA | `github-actions-deploy-prod` | ✅ |
+| WIF Pool/Provider/SA バインド | — | ✅ (後述の改善点参照) |
+
+### GitHub Actions SA IAM ロール
+
+| ロール | 状態 |
+|--------|------|
+| `roles/artifactregistry.writer` | ✅ |
+| `roles/run.developer` | ✅ |
+| `roles/iam.serviceAccountUser` | ✅ |
+| `roles/storage.admin` | ✅ |
+| `roles/cloudscheduler.admin` | ✅ |
+| `roles/resourcemanager.projectIamAdmin` | ✅ |
+| `roles/secretmanager.admin` | ✅ |
+| `roles/serviceusage.serviceUsageAdmin` | ✅ |
+| `roles/iam.serviceAccountAdmin` | ✅ |
+| `roles/iam.workloadIdentityPoolAdmin` | ✅ (prod WIF Pool 管理のため追加、正当) |
+
+### GitHub Actions ワークフロー (`.github/workflows/cd-prod.yml`)
+
+| 要件 | 状態 |
+|------|------|
+| トリガー: `push: tags: ['v*']` | ✅ |
+| トリガー: `workflow_dispatch` + `target_tag` 入力 (ロールバック用) | ✅ |
+| `lint` ジョブ (ruff check / format) | ✅ |
+| `test` ジョブ (pytest, `not manual`) | ✅ |
+| `deploy` ジョブ (`needs: [lint, test]`) | ✅ |
+| `environment: prod` 指定 | ✅ |
+| `concurrency: deploy-prod` (cancel-in-progress: false) | ✅ |
+| WIF 認証 (`WIF_PROVIDER` / `WIF_SERVICE_ACCOUNT`) | ✅ |
+| Docker 認証 (Artifact Registry) | ✅ |
+| `uv export` → Docker build (push イベント時のみ) | ✅ |
+| SHA タグ + release タグ push | ✅ |
+| Terraform には SHA URL を渡す | ✅ |
+| ロールバック時: 既存イメージの存在確認 + 再ビルドなし | ✅ |
+| Terraform apply (通常・ロールバック共通) | ✅ |
+| `prod-latest` 更新は Terraform apply 成功後のみ (push 時) | ✅ |
+
+### イメージタグ戦略
+
+| 要件 | 状態 |
+|------|------|
+| Terraform `image_url` に SHA タグ使用 (毎回差分を検出) | ✅ |
+| `prod-latest` タグを push イベント時に Artifact Registry へ push | ✅ |
+| release タグ (`v1.x.x`) を同時 push | ✅ |
+| `prod-latest` は apply 成功後にのみ更新 | ✅ |
+
+---
+
+## プランからの変更点（合意済み）
+
+プランの「modules/ 変更なし」の記述に反し、以下の変更が加えられた。これはユーザーとの対話で合意された必要な変更であり、正当と判断する。
+
+| 変更ファイル | 変更内容 | 評価 |
+|------------|---------|------|
+| `modules/workload_identity/variables.tf` | `pool_id`・`sa_account_id` 変数を追加（デフォルト値あり） | ✅ 後方互換性維持 |
+| `modules/workload_identity/main.tf` | pool_id・account_id をハードコードから変数参照に変更 | ✅ dev への影響なし |
+| `prod/main.tf` の WIF 設計 | dev WIF Pool 参照ではなく prod 専用 Pool を作成 | ✅ 要求に沿った改善 |
+
+---
+
+## テスト・静的解析結果
+
+### Terraform validate
+
+```
+# prod 環境
+$ terraform init -backend=false && terraform validate
+Success! The configuration is valid.
+
+# dev 環境（後方互換確認）
+$ terraform init -backend=false && terraform validate
+Success! The configuration is valid.
+```
+
+### ruff lint / format
+
+```
+$ uv run ruff check v2/
+All checks passed!
+
+$ uv run ruff format --check v2/
+21 files already formatted
+```
+
+### pytest
+
+```
+$ uv run pytest tests/unit/ tests/integration/ -m "not manual" -q
+37 passed, 3 deselected in 0.30s
+```
+
+---
+
+## 修正指示
+
+なし（全テスト・静的解析 PASS、全要件カバー済み）

--- a/terraform/environments/prod/.terraform.lock.hcl
+++ b/terraform/environments/prod/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:79CwMTsp3Ud1nOl5hFS5mxQHyT0fGVye7pqpU0PPlHI=",
+    "zh:1f3513fcfcbf7ca53d667a168c5067a4dd91a4d4cccd19743e248ff31065503c",
+    "zh:3da7db8fc2c51a77dd958ea8baaa05c29cd7f829bd8941c26e2ea9cb3aadc1e5",
+    "zh:3e09ac3f6ca8111cbb659d38c251771829f4347ab159a12db195e211c76068bb",
+    "zh:7bb9e41c568df15ccf1a8946037355eefb4dfb4e35e3b190808bb7c4abae547d",
+    "zh:81e5d78bdec7778e6d67b5c3544777505db40a826b6eb5abe9b86d4ba396866b",
+    "zh:8d309d020fb321525883f5c4ea864df3d5942b6087f6656d6d8b3a1377f340fc",
+    "zh:93e112559655ab95a523193158f4a4ac0f2bfed7eeaa712010b85ebb551d5071",
+    "zh:d3efe589ffd625b300cef5917c4629513f77e3a7b111c9df65075f76a46a63c7",
+    "zh:d4a4d672bbef756a870d8f32b35925f8ce2ef4f6bbd5b71a3cb764f1b6c85421",
+    "zh:e13a86bca299ba8a118e80d5f84fbdd708fe600ecdceea1a13d4919c068379fe",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
+  ]
+}

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -1,0 +1,175 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+  backend "gcs" {
+    bucket = "marufeuille-linebot-terraform-backend"
+    prefix = "terraform/environments/prod"
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+# ---------------------------------------------------------------------------
+# プロジェクト情報
+# ---------------------------------------------------------------------------
+
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+# ---------------------------------------------------------------------------
+# Cloud Run Job 実行用 Service Account
+# ---------------------------------------------------------------------------
+
+resource "google_service_account" "cloud_run" {
+  project      = var.project_id
+  account_id   = "school-agent-v2-prod"
+  display_name = "school-agent-v2 prod 実行用 SA"
+}
+
+resource "google_project_iam_member" "vertex_ai_user" {
+  project = var.project_id
+  role    = "roles/aiplatform.user"
+  member  = "serviceAccount:${google_service_account.cloud_run.email}"
+}
+
+resource "google_service_account_iam_member" "scheduler_token_creator" {
+  service_account_id = google_service_account.cloud_run.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudscheduler.iam.gserviceaccount.com"
+}
+
+# ---------------------------------------------------------------------------
+# Artifact Registry (prod 専用リポジトリ)
+# ---------------------------------------------------------------------------
+
+module "artifact_registry" {
+  source = "../../modules/artifact_registry"
+
+  project_id    = var.project_id
+  region        = var.region
+  repository_id = "school-agent-prod"
+  environment   = "prod"
+}
+
+# ---------------------------------------------------------------------------
+# Secret Manager
+# ---------------------------------------------------------------------------
+
+module "secret_slack_bot_token" {
+  source = "../../modules/secret_manager"
+
+  project_id            = var.project_id
+  secret_id             = "school-agent-slack-bot-token-prod"
+  service_account_email = google_service_account.cloud_run.email
+}
+
+module "secret_slack_channel_id" {
+  source = "../../modules/secret_manager"
+
+  project_id            = var.project_id
+  secret_id             = "school-agent-slack-channel-id-prod"
+  service_account_email = google_service_account.cloud_run.email
+}
+
+module "secret_todoist_api_token" {
+  source = "../../modules/secret_manager"
+
+  project_id            = var.project_id
+  secret_id             = "school-agent-todoist-api-token-prod"
+  service_account_email = google_service_account.cloud_run.email
+}
+
+# ---------------------------------------------------------------------------
+# Cloud Run Job
+# ---------------------------------------------------------------------------
+
+module "cloud_run_job" {
+  source = "../../modules/cloud_run_job"
+
+  project_id                    = var.project_id
+  region                        = var.region
+  job_name                      = "school-agent-v2-prod"
+  image_url                     = var.image_url
+  service_account_email         = google_service_account.cloud_run.email
+  invoker_service_account_email = google_service_account.cloud_run.email
+
+  env_vars = {
+    PROJECT_ID        = var.project_id
+    SPREADSHEET_ID    = var.spreadsheet_id
+    INBOX_FOLDER_ID   = var.inbox_folder_id
+    ARCHIVE_FOLDER_ID = var.archive_folder_id
+  }
+
+  secret_env_vars = {
+    SLACK_BOT_TOKEN   = module.secret_slack_bot_token.secret_id
+    SLACK_CHANNEL_ID  = module.secret_slack_channel_id.secret_id
+    TODOIST_API_TOKEN = module.secret_todoist_api_token.secret_id
+  }
+
+  depends_on = [
+    module.secret_slack_bot_token,
+    module.secret_slack_channel_id,
+    module.secret_todoist_api_token,
+  ]
+}
+
+# ---------------------------------------------------------------------------
+# Cloud Scheduler
+# ---------------------------------------------------------------------------
+
+module "cloud_scheduler" {
+  source = "../../modules/cloud_scheduler"
+
+  project_id            = var.project_id
+  region                = var.region
+  job_name              = "school-agent-v2-scheduler-prod"
+  schedule              = "0 9,17 * * *"
+  time_zone             = "Asia/Tokyo"
+  target_url            = module.cloud_run_job.job_api_uri
+  service_account_email = google_service_account.cloud_run.email
+}
+
+# ---------------------------------------------------------------------------
+# Workload Identity Federation (prod 専用)
+# dev とは別の Pool/Provider/SA を作成し、独立して管理する
+# ---------------------------------------------------------------------------
+
+module "workload_identity" {
+  source        = "../../modules/workload_identity"
+  project_id    = var.project_id
+  github_repo   = "marufeuille/ClearBag"
+  pool_id       = "github-actions-prod"
+  sa_account_id = "github-actions-deploy-prod"
+}
+
+# GitHub Actions prod SA に付与する IAM ロール
+locals {
+  github_actions_prod_roles = [
+    "roles/artifactregistry.writer",         # Docker イメージ push
+    "roles/run.developer",                   # Cloud Run Job 更新
+    "roles/iam.serviceAccountUser",          # Cloud Run SA として実行
+    "roles/storage.admin",                   # Terraform state (GCS) 読み書き
+    "roles/cloudscheduler.admin",            # Cloud Scheduler 管理
+    "roles/resourcemanager.projectIamAdmin", # terraform が IAM ポリシーを変更するため
+    "roles/secretmanager.admin",             # Secret Manager リソースの参照・管理
+    "roles/serviceusage.serviceUsageAdmin",  # API 有効化 (google_project_service)
+    "roles/iam.serviceAccountAdmin",         # SA の作成・管理
+    "roles/iam.workloadIdentityPoolAdmin",   # WIF Pool/Provider の管理
+  ]
+}
+
+resource "google_project_iam_member" "github_actions_prod" {
+  for_each = toset(local.github_actions_prod_roles)
+  project  = var.project_id
+  role     = each.value
+  member   = "serviceAccount:${module.workload_identity.service_account_email}"
+}

--- a/terraform/environments/prod/outputs.tf
+++ b/terraform/environments/prod/outputs.tf
@@ -1,0 +1,29 @@
+output "registry_url" {
+  description = "prod 環境の Artifact Registry URL"
+  value       = module.artifact_registry.registry_url
+}
+
+output "image_base" {
+  description = "prod 環境のイメージ名ベース"
+  value       = module.artifact_registry.image_base
+}
+
+output "job_name" {
+  description = "prod 環境の Cloud Run Job 名"
+  value       = module.cloud_run_job.job_name
+}
+
+output "service_account_email" {
+  description = "prod 環境の Cloud Run 実行 SA メールアドレス"
+  value       = google_service_account.cloud_run.email
+}
+
+output "workload_identity_provider" {
+  description = "GitHub Actions WIF Provider のフルパス（GitHub Environment Secret: WIF_PROVIDER に設定）"
+  value       = module.workload_identity.workload_identity_provider
+}
+
+output "github_actions_service_account_email" {
+  description = "GitHub Actions prod デプロイ用 SA メールアドレス（GitHub Environment Secret: WIF_SERVICE_ACCOUNT に設定）"
+  value       = module.workload_identity.service_account_email
+}

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -1,0 +1,30 @@
+variable "project_id" {
+  description = "prod 環境の GCP プロジェクトID"
+  type        = string
+}
+
+variable "region" {
+  description = "デプロイリージョン"
+  type        = string
+  default     = "asia-northeast1"
+}
+
+variable "image_url" {
+  description = "デプロイするコンテナイメージ URL（SHA タグ付き。deploy 時に -var で渡す）"
+  type        = string
+}
+
+variable "spreadsheet_id" {
+  description = "Google スプレッドシートID"
+  type        = string
+}
+
+variable "inbox_folder_id" {
+  description = "受信フォルダID（Google Drive）"
+  type        = string
+}
+
+variable "archive_folder_id" {
+  description = "アーカイブフォルダID（Google Drive）"
+  type        = string
+}

--- a/terraform/modules/workload_identity/main.tf
+++ b/terraform/modules/workload_identity/main.tf
@@ -4,7 +4,7 @@ data "google_project" "project" {
 
 resource "google_iam_workload_identity_pool" "github" {
   project                   = var.project_id
-  workload_identity_pool_id = "github-actions"
+  workload_identity_pool_id = var.pool_id
   display_name              = "GitHub Actions"
   description               = "GitHub Actions OIDC 認証用 Workload Identity Pool"
 }
@@ -36,7 +36,7 @@ resource "google_iam_workload_identity_pool_provider" "github" {
 
 resource "google_service_account" "github_actions" {
   project      = var.project_id
-  account_id   = "github-actions-deploy"
+  account_id   = var.sa_account_id
   display_name = "GitHub Actions デプロイ用 SA"
   description  = "GitHub Actions から GCP リソースを操作するためのサービスアカウント"
 }

--- a/terraform/modules/workload_identity/variables.tf
+++ b/terraform/modules/workload_identity/variables.tf
@@ -7,3 +7,15 @@ variable "github_repo" {
   description = "GitHub リポジトリ名（'owner/repo' 形式）。WIF の attribute_condition に使用し、他リポジトリからの認証を防止する。"
   type        = string
 }
+
+variable "pool_id" {
+  description = "Workload Identity Pool の ID"
+  type        = string
+  default     = "github-actions"
+}
+
+variable "sa_account_id" {
+  description = "GitHub Actions デプロイ用 Service Account の account_id"
+  type        = string
+  default     = "github-actions-deploy"
+}


### PR DESCRIPTION
## Summary

- GitHub tag push (`v*`) をトリガーとする prod CD パイプライン (`cd-prod.yml`) を新規作成
- `terraform/environments/prod/` を新規作成し、Cloud Run Job・Cloud Scheduler・Secret Manager・Artifact Registry・WIF を Terraform 管理下に置く
- `modules/workload_identity` の `pool_id` / `sa_account_id` を変数化し、dev は後方互換デフォルト値を維持しつつ prod は独立した WIF Pool (`github-actions-prod`) を持つよう改善

## 主な設計ポイント

- **イメージタグ戦略**: Terraform `image_url` には SHA タグ (`<sha7>`) を使用し、毎 release で Cloud Run Job の差分を確実に検出。`prod-latest` タグは apply 成功後のみ更新
- **ロールバック**: `workflow_dispatch` + `target_tag` 入力で既存イメージを再デプロイ（再ビルドなし）。緊急時は `gcloud run jobs update` で手動対応
- **WIF 分離**: dev の `github-actions` Pool とは独立した prod 専用 Pool を作成し、相互依存を排除

## Test plan

- [x] `terraform validate` (prod / dev 両方) PASS
- [x] `ruff check` / `ruff format --check` PASS
- [x] `pytest tests/unit/ tests/integration/ -m "not manual"` 37 passed

## 初回デプロイ手順（マージ後）

1. ローカルで `terraform init && terraform apply`（image_url はプレースホルダ可）
2. `terraform output` から `WIF_PROVIDER` / `WIF_SERVICE_ACCOUNT` を取得し GitHub prod Environment Secrets に設定
3. Secret Manager に prod の各 Secret 値を投入
4. `git tag v1.0.0 && git push origin v1.0.0` で初回リリース

🤖 Generated with [Claude Code](https://claude.com/claude-code)