### PR TITLE
fix: roles/run.developer を roles/run.admin に変更（run.jobs.setIamPolicy 不足の修正）

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -151,7 +151,7 @@ module "workload_identity" {
 locals {
   github_actions_roles = [
     "roles/artifactregistry.writer",         # Docker イメージ push
-    "roles/run.developer",                   # Cloud Run Job 更新
+    "roles/run.admin",                       # Cloud Run Job 更新・IAM ポリシー設定 (run.jobs.setIamPolicy が必要)
     "roles/iam.serviceAccountUser",          # Cloud Run SA として実行
     "roles/storage.admin",                   # Terraform state (GCS) 読み書き
     "roles/cloudscheduler.admin",            # Cloud Scheduler 管理

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -155,7 +155,7 @@ module "workload_identity" {
 locals {
   github_actions_prod_roles = [
     "roles/artifactregistry.writer",         # Docker イメージ push
-    "roles/run.developer",                   # Cloud Run Job 更新
+    "roles/run.admin",                       # Cloud Run Job 更新・IAM ポリシー設定 (run.jobs.setIamPolicy が必要)
     "roles/iam.serviceAccountUser",          # Cloud Run SA として実行
     "roles/storage.admin",                   # Terraform state (GCS) 読み書き
     "roles/cloudscheduler.admin",            # Cloud Scheduler 管理


### PR DESCRIPTION
## Summary

- terraform apply 時に Cloud Run Job の IAM バインド設定で 403 エラーが発生する問題を修正
- `roles/run.developer` → `roles/run.admin` に変更（dev・prod 両環境）

## 原因

`cloud_run_job` モジュール内の `google_cloud_run_v2_job_iam_member` リソースが Cloud Run Job に対して IAM ポリシーを設定しようとするが、`roles/run.developer` には `run.jobs.setIamPolicy` 権限が含まれていないため 403 が発生する。

```
Error: Permission 'run.jobs.setIamPolicy' denied on resource
'projects/.../jobs/school-agent-v2-prod'
```

`roles/run.admin` はこの権限を含むため、これに変更することで解決する。

## Test plan

- [x] `terraform validate` (dev・prod 両方) PASS 確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)