### PR TITLE
fix: monitoring.admin IAM 付与と prod Terraform の main push トリガー削除

### DIFF
--- a/.github/workflows/cd-prod-terraform.yml
+++ b/.github/workflows/cd-prod-terraform.yml
@@ -5,12 +5,6 @@ on:
     workflows: ["Build & Push Prod Image"]
     types: [completed]
 
-  push:
-    branches: [main]
-    paths:
-      - 'terraform/environments/prod/**'
-      - 'terraform/modules/**'
-
   workflow_dispatch:
 
 permissions:

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -168,6 +168,7 @@ locals {
     "roles/serviceusage.serviceUsageAdmin",  # API 有効化 (google_project_service)
     "roles/iam.serviceAccountAdmin",         # SA の作成・管理
     "roles/iam.workloadIdentityPoolAdmin",   # WIF Pool/Provider の管理
+    "roles/monitoring.admin",                # Cloud Monitoring アラートポリシー・通知チャンネル管理
   ]
 }
 

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -172,6 +172,7 @@ locals {
     "roles/serviceusage.serviceUsageAdmin",  # API 有効化 (google_project_service)
     "roles/iam.serviceAccountAdmin",         # SA の作成・管理
     "roles/iam.workloadIdentityPoolAdmin",   # WIF Pool/Provider の管理
+    "roles/monitoring.admin",                # Cloud Monitoring アラートポリシー・通知チャンネル管理
   ]
 }
 


### PR DESCRIPTION
## 背景

PR #29 の observability 改善実装後、2点の問題が発生。

## 修正内容

### 1. `roles/monitoring.admin` を dev/prod の GitHub Actions SA に追加

`terraform/environments/{dev,prod}/main.tf` の `github_actions_roles` に追加。

**原因**: Cloud Monitoring の通知チャンネル・アラートポリシーを Terraform で作成するには `monitoring.notificationChannels.create` / `monitoring.alertPolicies.create` 権限が必要だが、GitHub Actions SA に付与されていなかった。

**エラー**: `Error 403: Permission denied` on `google_monitoring_notification_channel`

### 2. `cd-prod-terraform.yml` から `push: branches: [main]` トリガーを削除

`terraform/modules/**` が main にマージされると prod Terraform が走るパスを削除。

**設計意図**: prod デプロイは `v*` タグ → ビルド完了 (`workflow_run`) → Terraform の順であり、main push では走らせない。

## Test plan

- [ ] CI で dev Terraform が 403 なしに成功すること
- [ ] main マージ後に `cd-prod-terraform.yml` が起動しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)