### PR TITLE
fix: monitoring モジュールの IAM 伝播 race condition を depends_on で解消

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -120,6 +120,10 @@ module "monitoring" {
   project_id         = var.project_id
   job_name           = module.cloud_run_job.job_name
   notification_email = var.notification_email
+
+  # IAM 付与と monitoring リソース作成の race condition を防ぐため、
+  # github_actions IAM メンバーが確定してから monitoring を作成する
+  depends_on = [google_project_iam_member.github_actions]
 }
 
 # ---------------------------------------------------------------------------

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -144,6 +144,10 @@ module "monitoring" {
   project_id         = var.project_id
   job_name           = module.cloud_run_job.job_name
   notification_email = var.notification_email
+
+  # IAM 付与と monitoring リソース作成の race condition を防ぐため、
+  # github_actions_prod IAM メンバーが確定してから monitoring を作成する
+  depends_on = [google_project_iam_member.github_actions_prod]
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 問題

`roles/monitoring.admin` の IAM 付与と `google_monitoring_notification_channel` の作成が
Terraform の並列実行で同時に走るため、権限伝播が間に合わず 403 エラーが発生していた。

```
08:37:15 roles/monitoring.admin IAM: Creating...
08:37:15 google_monitoring_notification_channel: Creating...  ← 同時スタート
08:37:23 IAM: Creation complete after 7s
08:37:23 Error 403: Permission denied  ← IAM が伝播する前に失敗
```

## 修正

`module "monitoring"` に `depends_on` を追加し、IAM メンバーが確定してから
monitoring リソースを作成するよう Terraform の実行順序を強制した。

- `dev/main.tf`: `depends_on = [google_project_iam_member.github_actions]`
- `prod/main.tf`: `depends_on = [google_project_iam_member.github_actions_prod]`

## Test plan

- [ ] CI で dev Terraform Apply が 403 なく成功すること
- [ ] monitoring リソース（通知チャンネル・アラートポリシー）が GCP コンソールで確認できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)