### PR TITLE
feat(terraform): Artifact Registry にクリーンアップポリシーを追加

### DIFF
--- a/terraform/modules/artifact_registry/main.tf
+++ b/terraform/modules/artifact_registry/main.tf
@@ -9,4 +9,23 @@ resource "google_artifact_registry_repository" "this" {
     environment = var.environment
     managed_by  = "terraform"
   }
+
+  # まず dry_run で動作確認してから false に切り替える
+  cleanup_policy_dry_run = true
+
+  cleanup_policies {
+    id     = "delete-old-images"
+    action = "DELETE"
+    condition {
+      older_than = "2592000s" # 30日
+    }
+  }
+
+  cleanup_policies {
+    id     = "keep-tagged-releases"
+    action = "KEEP"
+    condition {
+      tag_prefixes = ["latest", "latest-prod", "v"]
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- CDパイプラインのたびにSHAタグ付きコンテナイメージが蓄積し続ける問題を解消
- Artifact Registry リポジトリに2つのクリーンアップポリシーを追加
- `cleanup_policy_dry_run = true` で初回は dry run として適用（実削除なし）

## 変更内容

### `terraform/modules/artifact_registry/main.tf`

| ポリシー | アクション | 条件 |
|---------|-----------|------|
| `delete-old-images` | DELETE | 30日（2592000秒）以上経過したイメージ |
| `keep-tagged-releases` | KEEP | `latest` / `latest-prod` / `v*` タグ付きイメージ |

KEEP ポリシーは DELETE より優先されるため、リリースタグ付きイメージは保護される。

## Test plan

- [ ] `terraform plan` で差分が `cleanup_policies` の追加のみであることを確認
- [ ] `terraform apply` 後、GCPコンソール > Artifact Registry > クリーンアップポリシーで設定が反映されていることを確認
- [ ] Cloud Logging で dry run のログを確認し、削除対象が意図通りか確認
- [ ] 問題なければ `cleanup_policy_dry_run = false` に変更して再 apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)