### PR TITLE
feat(ci): デプロイワークフローに Slack 通知を追加

### DIFF
--- a/.github/workflows/_notify-slack.yml
+++ b/.github/workflows/_notify-slack.yml
@@ -1,0 +1,90 @@
+name: _Notify Slack
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: "デプロイ対象環境 (例: dev, prod)"
+        required: true
+        type: string
+      workflow_name:
+        description: "呼び出し元ワークフロー名 (例: CD (dev))"
+        required: true
+        type: string
+      result:
+        description: "デプロイジョブの結果 (success / failure / skipped / cancelled)"
+        required: true
+        type: string
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: true
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build notification metadata
+        id: meta
+        run: |
+          echo "short_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+          if [ "${{ inputs.result }}" = "success" ]; then
+            echo "header=✅ Deploy Succeeded" >> $GITHUB_OUTPUT
+          else
+            echo "header=❌ Deploy Failed" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "${{ steps.meta.outputs.header }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Environment*\n${{ inputs.environment }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow*\n${{ inputs.workflow_name }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Status*\n${{ inputs.result }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Commit*\n`${{ steps.meta.outputs.short_sha }}`"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Triggered by*\n${{ github.actor }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Run"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -127,3 +127,14 @@ jobs:
             -var="inbox_folder_id=${{ secrets.TF_VAR_INBOX_FOLDER_ID }}" \
             -var="archive_folder_id=${{ secrets.TF_VAR_ARCHIVE_FOLDER_ID }}" \
             -var="notification_email=${{ secrets.TF_VAR_NOTIFICATION_EMAIL }}"
+
+  notify:
+    needs: [lint, test, deploy]
+    if: always()
+    uses: ./.github/workflows/_notify-slack.yml
+    with:
+      environment: dev
+      workflow_name: "CD (dev)"
+      result: ${{ needs.deploy.result }}
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/cd-prod-build.yml
+++ b/.github/workflows/cd-prod-build.yml
@@ -152,3 +152,14 @@ jobs:
           docker pull "${TARGET_URL}"
           docker tag "${TARGET_URL}" "${LATEST_PROD_URL}"
           docker push "${LATEST_PROD_URL}"
+
+  notify:
+    needs: [lint, test, build-push]
+    if: always()
+    uses: ./.github/workflows/_notify-slack.yml
+    with:
+      environment: prod
+      workflow_name: "Build & Push Prod Image"
+      result: ${{ needs.build-push.result }}
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/cd-prod-terraform.yml
+++ b/.github/workflows/cd-prod-terraform.yml
@@ -59,3 +59,14 @@ jobs:
             -var="inbox_folder_id=${{ secrets.TF_VAR_INBOX_FOLDER_ID }}" \
             -var="archive_folder_id=${{ secrets.TF_VAR_ARCHIVE_FOLDER_ID }}" \
             -var="notification_email=${{ secrets.TF_VAR_NOTIFICATION_EMAIL }}"
+
+  notify:
+    needs: [deploy]
+    if: always()
+    uses: ./.github/workflows/_notify-slack.yml
+    with:
+      environment: prod
+      workflow_name: "CD Terraform (prod)"
+      result: ${{ needs.deploy.result }}
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary

- `_notify-slack.yml` を新規作成（Incoming Webhook 方式の Reusable Workflow）
- Block Kit 構造化メッセージ: ヘッダー(✅/❌) + 環境・ワークフロー・ステータス・Commit SHA・実行者 + "View Run" ボタン
- `cd-dev.yml` / `cd-prod-build.yml` / `cd-prod-terraform.yml` に `notify` ジョブを追加（`if: always()` で失敗時も通知）

## 事前に必要な手動作業

- [ ] Slack App で Incoming Webhooks を有効化し、通知先チャネルの Webhook URL を取得
- [ ] GitHub Secrets に `SLACK_WEBHOOK_URL` を追加（`Settings → Secrets and variables → Actions`）

## Test plan

- [ ] `workflow_dispatch` で `cd-dev.yml` を手動実行し、Slack に成功通知が届くことを確認
- [ ] テストを意図的に失敗させ、失敗通知が届くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)