### PR TITLE
fix(ci): notify ジョブから environment を削除 (uses: と共存不可)

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -131,7 +131,6 @@ jobs:
   notify:
     needs: [lint, test, deploy]
     if: always()
-    environment: dev
     uses: ./.github/workflows/_notify-slack.yml
     with:
       environment: dev

--- a/.github/workflows/cd-prod-build.yml
+++ b/.github/workflows/cd-prod-build.yml
@@ -156,7 +156,6 @@ jobs:
   notify:
     needs: [lint, test, build-push]
     if: always()
-    environment: prod
     uses: ./.github/workflows/_notify-slack.yml
     with:
       environment: prod

--- a/.github/workflows/cd-prod-terraform.yml
+++ b/.github/workflows/cd-prod-terraform.yml
@@ -63,7 +63,6 @@ jobs:
   notify:
     needs: [deploy]
     if: always()
-    environment: prod
     uses: ./.github/workflows/_notify-slack.yml
     with:
       environment: prod


### PR DESCRIPTION
## 問題

`uses:` (reusable workflow) と `environment:` は同一ジョブに共存できない GitHub Actions の制約があり、`cd-dev.yml` が workflow file error で失敗していた。

```
Missing required property: runs-on (Line 132)
Unexpected value: uses (Line 135)
```

## 修正

3ワークフローの `notify` ジョブから `environment:` を削除。

## SLACK_WEBHOOK_URL の設定方法

`environment:` が使えないため、`SLACK_WEBHOOK_URL` は **リポジトリレベルのシークレット** として設定する必要があります。

`Settings → Secrets and variables → Actions → Repository secrets → New repository secret`

Environment シークレットに設定した既存の値は削除またはそのままで問題ありません（リポジトリシークレットの方が優先されます）。

## Test plan

- [ ] `cd-dev.yml` が workflow file error なく起動することを確認
- [ ] リポジトリシークレットに `SLACK_WEBHOOK_URL` を追加後、Slack 通知が届くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)