### PR TITLE
fix(terraform): Cloud Scheduler を OIDC/OAuth 切り替え可能に

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -324,6 +324,7 @@ module "morning_digest_scheduler" {
   time_zone             = "Asia/Tokyo"
   target_url            = "${module.api_service.service_url}/worker/morning-digest"
   service_account_email = google_service_account.cloud_run.email
+  use_oidc              = true  # Cloud Run Service (run.app) の呼び出しには OIDC が必要
 
   depends_on = [module.api_service]
 }

--- a/terraform/modules/cloud_scheduler/main.tf
+++ b/terraform/modules/cloud_scheduler/main.tf
@@ -9,9 +9,20 @@ resource "google_cloud_scheduler_job" "this" {
     http_method = "POST"
     uri         = var.target_url
 
-    oauth_token {
-      service_account_email = var.service_account_email
-      scope                 = "https://www.googleapis.com/auth/cloud-platform"
+    dynamic "oauth_token" {
+      for_each = var.use_oidc ? [] : [1]
+      content {
+        service_account_email = var.service_account_email
+        scope                 = "https://www.googleapis.com/auth/cloud-platform"
+      }
+    }
+
+    dynamic "oidc_token" {
+      for_each = var.use_oidc ? [1] : []
+      content {
+        service_account_email = var.service_account_email
+        audience              = var.target_url
+      }
     }
   }
 }

--- a/terraform/modules/cloud_scheduler/variables.tf
+++ b/terraform/modules/cloud_scheduler/variables.tf
@@ -30,6 +30,12 @@ variable "target_url" {
 }
 
 variable "service_account_email" {
-  description = "OAuth トークン生成に使用するサービスアカウント"
+  description = "OAuth / OIDC トークン生成に使用するサービスアカウント"
   type        = string
+}
+
+variable "use_oidc" {
+  description = "true: OIDC トークン（Cloud Run Service の run.app URL 向け）/ false: OAuth トークン（googleapis.com API 向け）"
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
oauth_token は *.googleapis.com 専用。Cloud Run Service (run.app) の 呼び出しには oidc_token が必要。

- modules/cloud_scheduler: use_oidc 変数を追加し dynamic ブロックで切り替え
- dev/main.tf: morning_digest_scheduler に use_oidc = true を設定