### PR TITLE
fix(frontend/ci): next-pwa 型定義追加・notify の結果判定を修正

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -183,6 +183,7 @@ jobs:
     with:
       environment: dev
       workflow_name: "CD (dev)"
-      result: ${{ needs.deploy.result }}
+      # deploy と deploy-frontend の両方が成功した場合のみ success
+      result: ${{ (needs.deploy.result == 'success' && needs.deploy-frontend.result == 'success') && 'success' || 'failure' }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/frontend/next-pwa.d.ts
+++ b/frontend/next-pwa.d.ts
@@ -1,0 +1,2 @@
+// next-pwa には型定義がないため手動宣言
+declare module 'next-pwa';


### PR DESCRIPTION
- frontend/next-pwa.d.ts: next-pwa に型定義がないため declare module で宣言 （CI の TypeScript チェックで「Could not find declaration file」が出ていた）
- cd-dev.yml: notify の result を deploy + deploy-frontend 両方が success の場合のみ success に変更 （deploy-frontend 失敗でも成功通知が飛んでいた問題を修正）