### PR TITLE
fix(terraform): firebasehosting.googleapis.com を有効化

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -216,6 +216,12 @@ resource "google_project_service" "firebase" {
   disable_on_destroy = false
 }
 
+resource "google_project_service" "firebasehosting" {
+  project            = var.project_id
+  service            = "firebasehosting.googleapis.com"
+  disable_on_destroy = false
+}
+
 # 既存の Firestore (default) データベースを Terraform state に取り込む
 # 前回の apply で作成済みのため 409 が発生するのを防ぐ
 import {


### PR DESCRIPTION
firebase CLI が WIF 認証（marufeuille-linebot）経由で
firebasehosting.googleapis.com を呼び出すため、
marufeuille-linebot プロジェクトでの API 有効化が必要。