### PR TITLE
fix(api): CORS オリジンを環境変数で設定可能に・dev 環境を修正

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -311,6 +311,8 @@ module "api_service" {
     SERVICE_ACCOUNT_EMAIL   = google_service_account.cloud_run.email
     # ログイン許可メールアドレス（カンマ区切り）。未設定の場合は全員許可
     ALLOWED_EMAILS          = var.allowed_emails
+    # Firebase Hosting のオリジン（カンマ区切り）
+    CORS_ORIGINS            = "https://${var.firebase_project_id}.web.app,https://${var.firebase_project_id}.firebaseapp.com"
   }
 
   # SENDGRID_API_KEY / VAPID_PRIVATE_KEY は Secret Manager にまだ値が未登録のため

--- a/v2/entrypoints/api/app.py
+++ b/v2/entrypoints/api/app.py
@@ -51,12 +51,15 @@ app = FastAPI(
 )
 
 # ── CORS（PWA フロントエンドからのリクエストを許可） ─────────────────────────
+# CORS_ORIGINS 環境変数でカンマ区切りの追加オリジンを指定可能
+_extra_origins = [
+    o.strip() for o in os.environ.get("CORS_ORIGINS", "").split(",") if o.strip()
+]
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[
-        "https://clearbag.app",
-        "https://clearbag-dev.web.app",
         "http://localhost:3000",  # ローカル開発用
+        *_extra_origins,
     ],
     allow_credentials=True,
     allow_methods=["*"],


### PR DESCRIPTION
- app.py: CORS_ORIGINS 環境変数（カンマ区切り）で追加オリジンを注入可能に localhost:3000 はデフォルトで常に許可
- dev/main.tf: firebase_project_id から Firebase Hosting の .web.app / .firebaseapp.com オリジンを自動生成して CORS_ORIGINS に設定