### PR TITLE
fix(terraform): Cloud Run SA に自己 OIDC トークン生成権限を付与

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -39,6 +39,13 @@ resource "google_service_account_iam_member" "scheduler_token_creator" {
   member             = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudscheduler.iam.gserviceaccount.com"
 }
 
+# Cloud Run SA が Cloud Tasks タスク作成時に自分自身の OIDC トークンを生成するために必要
+resource "google_service_account_iam_member" "cloud_run_self_token_creator" {
+  service_account_id = google_service_account.cloud_run.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.cloud_run.email}"
+}
+
 module "artifact_registry" {
   source = "../../modules/artifact_registry"
 


### PR DESCRIPTION
Cloud Tasks タスク作成時に SA が自分自身の OIDC トークンを
生成するため、SA への serviceAccountTokenCreator を self-reference で付与。

PermissionDenied: lacks iam.serviceAccounts.actAs の修正。