### PR TITLE
fix(terraform): Cloud Tasks actAs 権限を serviceAccountUser に修正

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -237,6 +237,18 @@ import {
   id = "projects/marufeuille-linebot/databases/(default)"
 }
 
+# 手動作成した COLLECTION_GROUP インデックスを Terraform state に取り込む
+# （スコープ修正前に gcloud で作成済み → apply 時の 409 を防ぐ）
+import {
+  to = module.firestore.google_firestore_index.events_by_start
+  id = "projects/marufeuille-linebot/databases/(default)/collectionGroups/events/indexes/CICAgJim14AK"
+}
+
+import {
+  to = module.firestore.google_firestore_index.tasks_by_completed
+  id = "projects/marufeuille-linebot/databases/(default)/collectionGroups/tasks/indexes/CICAgJjF9oIK"
+}
+
 module "firestore" {
   source = "../../modules/firestore"
 

--- a/terraform/modules/firestore/main.tf
+++ b/terraform/modules/firestore/main.tf
@@ -16,11 +16,12 @@ resource "google_project_iam_member" "firestore_user" {
 }
 
 # コレクショングループクエリ用の複合インデックス
-# users/{uid}/events の start フィールドで日付範囲クエリを可能にする
+# users/{uid}/documents/{docId}/events をまたいだ日付範囲クエリに必要
 resource "google_firestore_index" "events_by_start" {
-  project    = var.project_id
-  database   = google_firestore_database.this.name
-  collection = "events"
+  project     = var.project_id
+  database    = google_firestore_database.this.name
+  collection  = "events"
+  query_scope = "COLLECTION_GROUP"
 
   fields {
     field_path = "user_uid"
@@ -37,9 +38,10 @@ resource "google_firestore_index" "events_by_start" {
 
 # tasks の completed フィールドでフィルタークエリを可能にする
 resource "google_firestore_index" "tasks_by_completed" {
-  project    = var.project_id
-  database   = google_firestore_database.this.name
-  collection = "tasks"
+  project     = var.project_id
+  database    = google_firestore_database.this.name
+  collection  = "tasks"
+  query_scope = "COLLECTION_GROUP"
 
   fields {
     field_path = "user_uid"


### PR DESCRIPTION
serviceAccountTokenCreator は getOpenIdToken を許可するが iam.serviceAccounts.actAs は含まない。
Cloud Tasks の OIDC タスク作成に必要なのは serviceAccountUser。

手動で即時付与済み。Terraform でコードと state を一致させる。