### PR TITLE
fix(terraform): dev 環境でドキュメント枚数制限を無効化

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -333,6 +333,8 @@ module "api_service" {
     SERVICE_ACCOUNT_EMAIL   = google_service_account.cloud_run.email
     # ログイン許可メールアドレス（カンマ区切り）。未設定の場合は全員許可
     ALLOWED_EMAILS          = var.allowed_emails
+    # 開発環境では枚数制限を無効化
+    DISABLE_RATE_LIMIT      = "true"
     # Firebase Hosting のオリジン（カンマ区切り）
     CORS_ORIGINS            = "https://${var.firebase_project_id}.web.app,https://${var.firebase_project_id}.firebaseapp.com"
   }


### PR DESCRIPTION
DISABLE_RATE_LIMIT=true を設定することで、開発・テスト中に
月間アップロード上限（free プラン）を気にせず動作確認できるようにする。