### PR TITLE
docs: README・SPECIFICATION・ARCHITECTURE を現状に合わせて更新

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,136 +1,203 @@
-# School Agent 仕様書
+# ClearBag システム仕様書
+
+> **注記**: 旧バッチシステム（school-agent v2 / Google Drive→Calendar/Todoist）の仕様は
+> [docs/plan/commercialization-mvp.md](docs/plan/commercialization-mvp.md) 実装以前のものです。
+> 現在のシステムは以下の B2C SaaS 仕様です。
+
+---
 
 ## 1. 目的
 
-学校や保育園から配布される非構造化データ（プリント類）の処理を自動化し、親の手を介さずにカレンダー登録やタスク化を行うこと。
-単なるOCRツールではなく、**「内容を理解し、親の代わりに整理してくれる秘書」** として機能する。
+学校・保育園から配布されるプリント（PDF・画像）をスマホで撮影・アップロードするだけで、
+Gemini 2.5 Pro が内容を解析し、予定とタスクを自動抽出する B2C SaaS。
 
-## 2. 要件
-
-### 2.1 機能要件
-
-1.  **入力:** 特定のGoogle Driveフォルダ (`Inbox`) にある画像やPDFを検知・読み込み。
-2.  **理解・抽出:** LLM (Gemini) を使用して、文書から「イベント」「アクション（タスク）」「メタデータ」を抽出。
-3.  **設定:** 対象となる人物（子供・親）やルールを外部ソース（Google Sheets）から動的に読み込む。
-4.  **スケジュール登録:** 抽出したイベントを対象者のGoogleカレンダーに登録。
-5.  **タスク管理:** アクションをTodoistに登録し、Slackで通知。
-6.  **整理:** 処理済みファイルを検索可能な形式 (`YYYYMMDD_タイトル`) にリネームし、`Archive` フォルダへ移動。
-
-### 2.2 非機能要件
-
-- **Google Ecosystem:** 主にGoogle Cloud (Drive, Vertex AI, Calendar) 上で構築。
-- **拡張性:** 子供の人数や学年の変化にコード修正なしで対応可能（Config駆動）。
-- **シンプルさ:** Pythonスクリプトのループとして実装。
+**コアバリュー**: 「撮って送るだけ」。保護者の代わりにお便りを読んで整理する AI 秘書。
 
 ---
 
-## 3. システムアーキテクチャ
+## 2. ユーザーフロー
 
-```mermaid
-graph TD
-    subgraph Storage
-    Inbox[Google Drive (Inbox)]
-    Archive[Google Drive (Archive)]
-    Config[Google Sheets (Config)]
-    end
-
-    subgraph Compute
-    Agent[Python Script (Agent Loop)]
-    end
-
-    subgraph AI
-    LLM[Gemini]
-    end
-
-    subgraph UserInterface
-    Cal[Google Calendar]
-    Slack[Slack Notification]
-    Todoist[Todoist Task]
-    end
-
-    Inbox -->|1. 新規ファイルスキャン| Agent
-    Config -->|2. ルール/プロファイル読込| Agent
-    Agent <-->|3. 解析 & 関数呼び出し| LLM
-    Agent -->|4. イベント作成| Cal
-    Agent -->|5. 通知| Slack
-    Agent -->|6. タスク作成| Todoist
-    Agent -->|7. リネーム & 移動| Archive
+```
+1. スマホで Firebase Auth（Google）ログイン
+2. お便り PDF・写真をアップロード（ドラッグ&ドロップ / カメラ撮影）
+3. 非同期で Gemini 2.5 Pro が解析（Cloud Tasks キュー）
+4. 解析結果がカレンダー・タスクに反映される
+5. iCal URL を Google カレンダー等に登録して自動同期
 ```
 
 ---
 
-## 4. データモデル (設定)
+## 3. 機能要件
 
-設定は **Google Sheets** で管理します。
+### 3.1 ドキュメント管理
 
-### シート1: `Profiles`
+| # | 機能 | 詳細 |
+|---|---|---|
+| F-01 | アップロード | PDF・JPG・PNG・WebP・HEIC 対応。最大ファイルサイズは GCS デフォルト |
+| F-02 | 重複チェック | SHA-256 コンテンツハッシュで冪等性確保 |
+| F-03 | 非同期解析 | Cloud Tasks → Worker（`/worker/analyze`）で非同期処理 |
+| F-04 | ステータス管理 | `pending` → `processing` → `completed` / `error` |
+| F-05 | 削除 | ドキュメント + 関連 events/tasks を Firestore から削除 |
 
-家族メンバーや処理対象を定義します。
+### 3.2 AI 解析
 
-| ID        | Name       | Grade | Keywords      | Calendar_ID        |
-| :-------- | :--------- | :---- | :------------ | :----------------- |
-| `CHILD1`  | 子供の名前 | 小3   | キーワード... | `calendar_id_1...` |
-| `CHILD2`  | 子供の名前 | 小1   | キーワード... | `calendar_id_2...` |
-| `PARENTS` | 両親       | -     | PTAなど       | `primary`          |
+| # | 機能 | 詳細 |
+|---|---|---|
+| F-10 | Gemini 呼び出し | Vertex AI Gemini 2.5 Pro（`gemini-2.5-pro`）|
+| F-11 | 抽出項目 | サマリー・カテゴリー・イベント（日時・場所）・タスク（期限・担当者）|
+| F-12 | confidence | HIGH / MEDIUM / LOW で信頼度を付与 |
+| F-13 | カテゴリー | `EVENT` / `TASK` / `INFO` / `IGNORE` |
+| F-14 | リトライ | tenacity で Vertex AI レート制限に対して指数バックオフリトライ |
 
-### シート2: `Rules`
+### 3.3 カレンダー
 
-特定の解析ルールやアクションルールを定義します。
+| # | 機能 | 詳細 |
+|---|---|---|
+| F-20 | イベント一覧 | 日付範囲フィルター（`?from=YYYY-MM-DD&to=YYYY-MM-DD`）|
+| F-21 | iCal フィード | トークンベース認証で認証不要の `.ics` エンドポイント |
+| F-22 | iCal URL | Cloud Run URL（`https://clearbag-api-{env}.run.app/api/ical/{token}`）|
 
-| Rule_ID | Target_Profile | Rule_Type  | Content                                               |
-| :------ | :------------- | :--------- | :---------------------------------------------------- |
-| `R001`  | `CHILD1`       | `REMINDER` | 持ち物が必要なイベントは3日前にタスク期限を設定する。 |
-| `R002`  | `ALL`          | `IGNORE`   | 広告や重要でないチラシは無視する。                    |
-| `R003`  | `ALL`          | `NAMING`   | ファイル名は `YYYYMMDD_タイトル` にリネームする。     |
+### 3.4 タスク管理
+
+| # | 機能 | 詳細 |
+|---|---|---|
+| F-30 | タスク一覧 | 完了フィルター（`?completed=false`）|
+| F-31 | 完了チェック | PATCH で `completed: true/false` を更新 |
+
+### 3.5 プロファイル
+
+| # | 機能 | 詳細 |
+|---|---|---|
+| F-40 | CRUD | 家族メンバー（名前・学年・キーワード）の登録・更新・削除 |
+| F-41 | 解析精度向上 | プロファイルのキーワードを Gemini プロンプトに注入 |
+
+### 3.6 ユーザー設定
+
+| # | 機能 | 詳細 |
+|---|---|---|
+| F-50 | iCal トークン | 初回アクセス時に自動生成・Firestore に永続化 |
+| F-51 | 解析枚数 | 今月の利用枚数を表示（無料プラン上限: 5枚）|
+
+### 3.7 朝のダイジェスト
+
+| # | 機能 | 詳細 |
+|---|---|---|
+| F-60 | スケジューラー | 毎朝 7:30 JST に Cloud Scheduler が `/worker/morning-digest` を呼び出し |
+| F-61 | 通知内容 | 未完了タスク・今後7日間の予定を通知（SendGrid/WebPush、設定で ON/OFF）|
 
 ---
 
-## 5. インターフェース設計 (LLM)
+## 4. 非機能要件
 
-### 5.1 システムプロンプト
+### 4.1 プラン制限
 
-> あなたは家族の事務を管理する優秀なAIエージェントです。
-> 提供された画像/PDFを読み、Google Sheetsから読み込まれた `Profiles` と `Rules` に基づいて、
-> 適切なツール（カレンダー、タスク、アーカイブ）を実行するための情報を抽出してください。
+| プラン | 月間解析枚数 |
+|---|---|
+| Free | 5枚 |
+| Premium | 無制限（未実装） |
 
-### 5.2 出力スキーマ (JSON)
+環境変数 `DISABLE_RATE_LIMIT=true` でスキップ可（dev 環境推奨）。
 
-```json
-{
-  "summary": "文書の要約。",
-  "category": "EVENT",
-  "related_profile_ids": ["CHILD1"],
-  "events": [
-    {
-      "summary": "[長男] 遠足",
-      "start": "2025-10-25T08:30:00",
-      "end": "2025-10-25T15:00:00",
-      "location": "場所名",
-      "description": "詳細..."
-    }
-  ],
-  "tasks": [
-    {
-      "title": "同意書の提出",
-      "due_date": "2025-10-10",
-      "assignee": "PARENT",
-      "note": "署名が必要です。"
-    }
-  ],
-  "archive_filename": "20251025_遠足_長男.pdf"
-}
+### 4.2 アクセス制御
+
+- Firebase Authentication（Google Sign-in）で全 API を保護
+- `ALLOWED_EMAILS` 環境変数でログイン可能アカウントを制限（空で全員許可）
+- Cloud Tasks Worker は OIDC トークンで保護（Firebase Auth 不要）
+- iCal エンドポイントはトークンベース（認証ヘッダー不要）
+
+### 4.3 パフォーマンス
+
+- アップロード API は 202 Accepted を即返し、解析は非同期（Cloud Tasks）
+- Gemini のレート制限に合わせて Cloud Tasks キューを 1 rps / 同時3件に制限
+- `COLLECTION_GROUP` スコープの Firestore 複合インデックスで横断クエリを高速化
+
+### 4.4 インフラ
+
+- **環境**: dev / prod を Terraform で完全管理
+- **認証**: Workload Identity Federation（サービスアカウントキー不使用）
+- **CI/CD**: main push → lint → test → Docker build → Terraform apply → Firebase Hosting deploy
+
+---
+
+## 5. データモデル（Firestore）
+
+```
+users/{uid}                               ← ユーザー設定（plan, ical_token 等）
+users/{uid}/profiles/{profileId}          ← 家族プロファイル
+users/{uid}/documents/{documentId}        ← ドキュメントレコード
+users/{uid}/documents/{docId}/events/{eventId}  ← 抽出イベント（非正規化）
+users/{uid}/documents/{docId}/tasks/{taskId}    ← 抽出タスク（非正規化）
 ```
 
+### Firestore インデックス
+
+イベント・タスクは `collection_group()` クエリで全ドキュメントをまたいで取得するため、
+**`COLLECTION_GROUP` スコープ**の複合インデックスが必要。
+
+| コレクション | フィールド | 用途 |
+|---|---|---|
+| `events` | `user_uid` ASC + `start` ASC | 日付範囲クエリ・iCal |
+| `tasks` | `user_uid` ASC + `completed` ASC | 完了フィルタークエリ |
+
+> **注意**: Terraform の `google_firestore_index` は `query_scope = "COLLECTION_GROUP"` の明示が必要。省略すると `COLLECTION` になり `collection_group()` クエリで 400 エラーになる。
+
 ---
 
-## 6. 処理フロー
+## 6. API エンドポイント
 
-1.  **初期化:** Google Sheetsから `Profiles` と `Rules` を読み込む。
-2.  **スキャン:** `Inbox` 内のファイルリストを取得。
-3.  **ループ:** 各ファイルについて:
-    - **思考 (Think):** コンテキストと共にGeminiにアップロード。
-    - **行動 (Act):**
-      - `add_calendar_event` (カレンダー登録)
-      - `create_todoist_task` (タスク登録)
-      - `send_slack_notification` (通知)
-    - **完了 (Finish):** ファイルをリネームして `Archive` へ移動。
+| Method | Path | 認証 | 説明 |
+|---|---|---|---|
+| `POST` | `/api/documents/upload` | Firebase Auth | ファイルアップロード（202 Accepted）|
+| `GET` | `/api/documents` | Firebase Auth | ドキュメント一覧 |
+| `GET` | `/api/documents/{id}` | Firebase Auth | ドキュメント詳細 |
+| `DELETE` | `/api/documents/{id}` | Firebase Auth | ドキュメント削除 |
+| `GET` | `/api/events` | Firebase Auth | イベント一覧（日付範囲フィルター）|
+| `GET` | `/api/tasks` | Firebase Auth | タスク一覧 |
+| `PATCH` | `/api/tasks/{id}` | Firebase Auth | タスク完了状態更新 |
+| `GET` | `/api/profiles` | Firebase Auth | プロファイル一覧 |
+| `POST` | `/api/profiles` | Firebase Auth | プロファイル作成 |
+| `PUT` | `/api/profiles/{id}` | Firebase Auth | プロファイル更新 |
+| `DELETE` | `/api/profiles/{id}` | Firebase Auth | プロファイル削除 |
+| `GET` | `/api/settings` | Firebase Auth | ユーザー設定取得 |
+| `PATCH` | `/api/settings` | Firebase Auth | ユーザー設定更新 |
+| `GET` | `/api/ical/{token}` | トークンのみ | iCal フィード（認証ヘッダー不要）|
+| `POST` | `/worker/analyze` | OIDC | 解析ジョブ実行（Cloud Tasks から呼び出し）|
+| `POST` | `/worker/morning-digest` | OIDC | 朝のダイジェスト送信（Cloud Scheduler から呼び出し）|
+| `GET` | `/health` | なし | ヘルスチェック |
+
+---
+
+## 7. 環境変数
+
+### バックエンド（Cloud Run / ローカル）
+
+| 変数名 | 説明 | ローカルデフォルト |
+|---|---|---|
+| `PROJECT_ID` | GCP プロジェクト ID | 要設定 |
+| `FIREBASE_PROJECT_ID` | Firebase プロジェクト ID | 要設定 |
+| `GCS_BUCKET_NAME` | アップロード先 GCS バケット | `clearbag-local` |
+| `CLOUD_TASKS_QUEUE` | Cloud Tasks キュー ID | — |
+| `CLOUD_TASKS_LOCATION` | Cloud Tasks リージョン | — |
+| `VERTEX_AI_LOCATION` | Vertex AI リージョン | `asia-northeast1` |
+| `GEMINI_MODEL` | Gemini モデル名 | `gemini-2.5-pro` |
+| `API_BASE_URL` | iCal URL 生成用ベース URL | `""` |
+| `WORKER_URL` | Cloud Tasks が呼び出すワーカー URL | — |
+| `SERVICE_ACCOUNT_EMAIL` | Cloud Tasks OIDC 用 SA メール | — |
+| `ALLOWED_EMAILS` | ログイン許可メール（カンマ区切り）| `""` = 全員許可 |
+| `DISABLE_RATE_LIMIT` | `true` で枚数制限スキップ | `true`（ローカル）|
+| `LOCAL_MODE` | `true` で Cloud Tasks をスキップ | `true`（ローカル）|
+| `CORS_ORIGINS` | 追加 CORS オリジン（カンマ区切り）| `""` |
+| `FIRESTORE_EMULATOR_HOST` | Firestore エミュレーター | `localhost:8089` |
+| `STORAGE_EMULATOR_HOST` | GCS エミュレーター | `http://localhost:4443` |
+
+### フロントエンド（Next.js）
+
+| 変数名 | 説明 |
+|---|---|
+| `NEXT_PUBLIC_FIREBASE_API_KEY` | Firebase ウェブアプリの API キー |
+| `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` | Firebase 認証ドメイン |
+| `NEXT_PUBLIC_FIREBASE_PROJECT_ID` | Firebase プロジェクト ID |
+| `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` | Firebase Storage バケット |
+| `NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID` | Firebase Messaging Sender ID |
+| `NEXT_PUBLIC_FIREBASE_APP_ID` | Firebase アプリ ID |
+| `NEXT_PUBLIC_API_BASE_URL` | バックエンド API URL（ローカル: `http://localhost:8000`）|


### PR DESCRIPTION
- README: GitHub Secrets 一覧・デプロイ手順・iCal URL 説明・朝のダイジェスト追加
- SPECIFICATION: v1 バッチシステム仕様 → B2C SaaS 仕様に全面書き直し （機能要件・データモデル・Firestore インデックス注意・環境変数一覧）
- ARCHITECTURE_V2: タイトル・概要を ClearBag に更新、 Phase 3/4 を「実装済み」として実際のアダプター・エントリポイントを列挙