### PR TITLE
feat: 家族機能 Phase 1+2 デプロイ準備

### DIFF
--- a/scripts/migrate_to_families.py
+++ b/scripts/migrate_to_families.py
@@ -1,0 +1,302 @@
+"""既存ユーザーデータをファミリー構造に移行するスクリプト
+
+実行方法:
+    # Firestore Emulator で検証する場合
+    FIRESTORE_EMULATOR_HOST=localhost:8080 python scripts/migrate_to_families.py --dry-run
+
+    # 本番実行
+    python scripts/migrate_to_families.py
+
+処理内容:
+  1. users/{uid} ごとに自動で1人ファミリーを作成
+  2. users/{uid}/profiles/* → families/{familyId}/profiles/* にコピー
+  3. users/{uid}/documents/* → families/{familyId}/documents/* にコピー
+  4. documents/{docId}/events/*.user_uid → family_id にフィールド変換
+  5. documents/{docId}/tasks/*.user_uid → family_id にフィールド変換
+  6. users/{uid} に family_id フィールドを追加
+  7. users/{uid} の plan/documents_this_month を families/{familyId} にコピー
+
+注意:
+  - 既に family_id が設定されているユーザーはスキップ（冪等）
+  - GCS ファイルの移行は別途 migrate_gcs_paths.py を使用（オプション）
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import uuid
+from typing import Any
+
+from google.cloud import firestore
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+_USERS = "users"
+_FAMILIES = "families"
+_PROFILES = "profiles"
+_DOCUMENTS = "documents"
+_EVENTS = "events"
+_TASKS = "tasks"
+_MEMBERS = "members"
+
+
+def migrate_user(
+    db: firestore.Client, uid: str, user_data: dict, dry_run: bool
+) -> str | None:
+    """
+    1ユーザーをファミリー構造に移行する。
+
+    Returns:
+        作成/既存のファミリーID。スキップ時はNone。
+    """
+    # 既に family_id が設定済みの場合はスキップ
+    if user_data.get("family_id"):
+        logger.info("SKIP uid=%s (already has family_id=%s)", uid, user_data["family_id"])
+        return None
+
+    family_id = str(uuid.uuid4())
+    email = user_data.get("email", "")
+    display_name = user_data.get("display_name", email or uid)
+    plan = user_data.get("plan", "free")
+    documents_this_month = user_data.get("documents_this_month", 0)
+
+    logger.info(
+        "MIGRATE uid=%s → family_id=%s (dry_run=%s)", uid, family_id, dry_run
+    )
+
+    if dry_run:
+        # プロファイル数とドキュメント数を確認
+        profiles = list(
+            db.collection(_USERS).document(uid).collection(_PROFILES).stream()
+        )
+        documents = list(
+            db.collection(_USERS).document(uid).collection(_DOCUMENTS).stream()
+        )
+        logger.info(
+            "  Would migrate: %d profiles, %d documents", len(profiles), len(documents)
+        )
+        return family_id
+
+    batch = db.batch()
+
+    # ── ファミリー作成 ──────────────────────────────────────────────────────
+    family_ref = db.collection(_FAMILIES).document(family_id)
+    batch.set(
+        family_ref,
+        {
+            "owner_uid": uid,
+            "name": "マイファミリー",
+            "plan": plan,
+            "documents_this_month": documents_this_month,
+            "created_at": firestore.SERVER_TIMESTAMP,
+            "updated_at": firestore.SERVER_TIMESTAMP,
+        },
+    )
+
+    # ── メンバー追加 ────────────────────────────────────────────────────────
+    member_ref = family_ref.collection(_MEMBERS).document(uid)
+    batch.set(
+        member_ref,
+        {
+            "role": "owner",
+            "display_name": display_name,
+            "email": email,
+            "joined_at": firestore.SERVER_TIMESTAMP,
+        },
+    )
+
+    # ── users/{uid} に family_id を書き込み ────────────────────────────────
+    user_ref = db.collection(_USERS).document(uid)
+    batch.update(user_ref, {"family_id": family_id})
+
+    batch.commit()
+    logger.info("  Created family and member")
+
+    # ── プロファイル移行 ────────────────────────────────────────────────────
+    _migrate_subcollection(
+        db,
+        src_path=f"{_USERS}/{uid}/{_PROFILES}",
+        dst_path=f"{_FAMILIES}/{family_id}/{_PROFILES}",
+    )
+
+    # ── ドキュメント移行 ────────────────────────────────────────────────────
+    _migrate_documents(db, uid=uid, family_id=family_id)
+
+    return family_id
+
+
+def _migrate_subcollection(
+    db: firestore.Client, src_path: str, dst_path: str
+) -> int:
+    """
+    サブコレクション全体をコピーする。
+
+    Returns:
+        コピーしたドキュメント数
+    """
+    parts = src_path.split("/")
+    src_ref = db
+    for i, part in enumerate(parts):
+        if i % 2 == 0:
+            src_ref = src_ref.collection(part)
+        else:
+            src_ref = src_ref.document(part)
+
+    snaps = list(src_ref.stream())
+    if not snaps:
+        return 0
+
+    dst_parts = dst_path.split("/")
+    dst_col = db
+    for i, part in enumerate(dst_parts):
+        if i % 2 == 0:
+            dst_col = dst_col.collection(part)
+        else:
+            dst_col = dst_col.document(part)
+
+    batch = db.batch()
+    count = 0
+    for snap in snaps:
+        data = snap.to_dict() or {}
+        dst_ref = dst_col.document(snap.id)
+        batch.set(dst_ref, data)
+        count += 1
+        # Firestore バッチの上限（500）に達したらコミット
+        if count % 400 == 0:
+            batch.commit()
+            batch = db.batch()
+
+    if count % 400 != 0:
+        batch.commit()
+
+    logger.info("  Copied %d docs: %s → %s", count, src_path, dst_path)
+    return count
+
+
+def _migrate_documents(
+    db: firestore.Client, uid: str, family_id: str
+) -> None:
+    """
+    ドキュメントとそのサブコレクション（events, tasks）を移行する。
+    user_uid フィールドを family_id に変換する。
+    """
+    docs_src = db.collection(_USERS).document(uid).collection(_DOCUMENTS)
+    docs_dst = db.collection(_FAMILIES).document(family_id).collection(_DOCUMENTS)
+
+    for doc_snap in docs_src.stream():
+        doc_data = doc_snap.to_dict() or {}
+        doc_id = doc_snap.id
+
+        # ドキュメント本体をコピー
+        docs_dst.document(doc_id).set(doc_data)
+
+        # events サブコレクションを移行（user_uid → family_id）
+        _migrate_events_or_tasks(
+            db,
+            src_col=docs_src.document(doc_id).collection(_EVENTS),
+            dst_col=docs_dst.document(doc_id).collection(_EVENTS),
+            family_id=family_id,
+        )
+
+        # tasks サブコレクションを移行（user_uid → family_id）
+        _migrate_events_or_tasks(
+            db,
+            src_col=docs_src.document(doc_id).collection(_TASKS),
+            dst_col=docs_dst.document(doc_id).collection(_TASKS),
+            family_id=family_id,
+        )
+
+    # 移行したドキュメント数をログ出力
+    doc_count = sum(1 for _ in docs_dst.stream())
+    logger.info("  Migrated %d documents to family_id=%s", doc_count, family_id)
+
+
+def _migrate_events_or_tasks(
+    db: firestore.Client,
+    src_col: Any,
+    dst_col: Any,
+    family_id: str,
+) -> None:
+    """events または tasks サブコレクションを移行し、user_uid → family_id に変換"""
+    batch = db.batch()
+    count = 0
+    for snap in src_col.stream():
+        data = snap.to_dict() or {}
+        # user_uid フィールドを family_id に変換
+        if "user_uid" in data:
+            data["family_id"] = family_id
+            del data["user_uid"]
+        dst_col.document(snap.id).set(data)
+        batch.set(dst_col.document(snap.id), data)
+        count += 1
+        if count % 400 == 0:
+            batch.commit()
+            batch = db.batch()
+    if count % 400 != 0 and count > 0:
+        batch.commit()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Migrate existing users to family structure"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run without making any changes (preview only)",
+    )
+    parser.add_argument(
+        "--uid",
+        type=str,
+        default=None,
+        help="Migrate only this specific uid (optional)",
+    )
+    args = parser.parse_args()
+
+    db = firestore.Client()
+
+    if args.uid:
+        # 特定ユーザーのみ移行
+        snap = db.collection(_USERS).document(args.uid).get()
+        if not snap.exists:
+            logger.error("User not found: uid=%s", args.uid)
+            return
+        migrate_user(db, args.uid, snap.to_dict() or {}, dry_run=args.dry_run)
+    else:
+        # 全ユーザーを移行
+        users = list(db.collection(_USERS).stream())
+        logger.info("Found %d users to migrate", len(users))
+
+        migrated = 0
+        skipped = 0
+        errors = 0
+
+        for user_snap in users:
+            uid = user_snap.id
+            try:
+                result = migrate_user(
+                    db, uid, user_snap.to_dict() or {}, dry_run=args.dry_run
+                )
+                if result:
+                    migrated += 1
+                else:
+                    skipped += 1
+            except Exception:
+                logger.exception("Migration failed for uid=%s", uid)
+                errors += 1
+
+        logger.info(
+            "Migration complete: migrated=%d, skipped=%d, errors=%d",
+            migrated,
+            skipped,
+            errors,
+        )
+
+    if args.dry_run:
+        logger.info("DRY RUN: No changes were made")
+
+
+if __name__ == "__main__":
+    main()

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -237,17 +237,6 @@ import {
   id = "projects/marufeuille-linebot/databases/(default)"
 }
 
-# 手動作成した COLLECTION_GROUP インデックスを Terraform state に取り込む
-# （スコープ修正前に gcloud で作成済み → apply 時の 409 を防ぐ）
-import {
-  to = module.firestore.google_firestore_index.events_by_start
-  id = "projects/marufeuille-linebot/databases/(default)/collectionGroups/events/indexes/CICAgJim14AK"
-}
-
-import {
-  to = module.firestore.google_firestore_index.tasks_by_completed
-  id = "projects/marufeuille-linebot/databases/(default)/collectionGroups/tasks/indexes/CICAgJjF9oIK"
-}
 
 module "firestore" {
   source = "../../modules/firestore"

--- a/terraform/modules/firestore/main.tf
+++ b/terraform/modules/firestore/main.tf
@@ -24,7 +24,7 @@ resource "google_firestore_index" "events_by_start" {
   query_scope = "COLLECTION_GROUP"
 
   fields {
-    field_path = "user_uid"
+    field_path = "family_id"
     order      = "ASCENDING"
   }
 
@@ -44,12 +44,32 @@ resource "google_firestore_index" "tasks_by_completed" {
   query_scope = "COLLECTION_GROUP"
 
   fields {
-    field_path = "user_uid"
+    field_path = "family_id"
     order      = "ASCENDING"
   }
 
   fields {
     field_path = "completed"
+    order      = "ASCENDING"
+  }
+
+  depends_on = [google_firestore_database.this]
+}
+
+# 招待トークンで招待情報を検索するための collection_group インデックス
+resource "google_firestore_index" "invitations_by_token" {
+  project     = var.project_id
+  database    = google_firestore_database.this.name
+  collection  = "invitations"
+  query_scope = "COLLECTION_GROUP"
+
+  fields {
+    field_path = "token"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "__name__"
     order      = "ASCENDING"
   }
 

--- a/tests/unit/test_api_documents.py
+++ b/tests/unit/test_api_documents.py
@@ -12,17 +12,21 @@ from fastapi.testclient import TestClient
 from v2.domain.models import DocumentRecord
 from v2.entrypoints.api.app import app
 from v2.entrypoints.api.deps import (
+    FamilyContext,
     get_blob_storage,
-    get_current_uid,
     get_document_repo,
+    get_family_context,
+    get_family_repo,
     get_task_queue,
-    get_user_config_repo,
 )
 
 _UID = "test-user-uid"
+_FAMILY_ID = "test-family-id"
 _DOC_ID = "test-doc-id"
 _CONTENT = b"fake-pdf-content"
 _HASH = hashlib.sha256(_CONTENT).hexdigest()
+
+_FAMILY_CONTEXT = FamilyContext(uid=_UID, family_id=_FAMILY_ID, role="owner")
 
 
 @pytest.fixture
@@ -36,7 +40,7 @@ def mock_doc_repo():
         uid=_UID,
         status="completed",
         content_hash=_HASH,
-        storage_path=f"uploads/{_UID}/{_DOC_ID}.pdf",
+        storage_path=f"uploads/{_FAMILY_ID}/{_DOC_ID}.pdf",
         original_filename="test.pdf",
         mime_type="application/pdf",
         summary="テスト文書",
@@ -46,16 +50,16 @@ def mock_doc_repo():
 
 
 @pytest.fixture
-def mock_user_repo():
+def mock_family_repo():
     repo = MagicMock()
-    repo.get_user.return_value = {"plan": "free", "documents_this_month": 0}
+    repo.get_family.return_value = {"plan": "free", "documents_this_month": 0}
     return repo
 
 
 @pytest.fixture
 def mock_storage():
     storage = MagicMock()
-    storage.upload.return_value = f"uploads/{_UID}/{_DOC_ID}.pdf"
+    storage.upload.return_value = f"uploads/{_FAMILY_ID}/{_DOC_ID}.pdf"
     return storage
 
 
@@ -65,11 +69,11 @@ def mock_queue():
 
 
 @pytest.fixture
-def client(mock_doc_repo, mock_user_repo, mock_storage, mock_queue):
+def client(mock_doc_repo, mock_family_repo, mock_storage, mock_queue):
     """モックを差し込んだ FastAPI テストクライアント"""
-    app.dependency_overrides[get_current_uid] = lambda: _UID
+    app.dependency_overrides[get_family_context] = lambda: _FAMILY_CONTEXT
     app.dependency_overrides[get_document_repo] = lambda: mock_doc_repo
-    app.dependency_overrides[get_user_config_repo] = lambda: mock_user_repo
+    app.dependency_overrides[get_family_repo] = lambda: mock_family_repo
     app.dependency_overrides[get_blob_storage] = lambda: mock_storage
     app.dependency_overrides[get_task_queue] = lambda: mock_queue
 
@@ -100,7 +104,7 @@ class TestUploadDocument:
             uid=_UID,
             status="completed",
             content_hash=_HASH,
-            storage_path="uploads/uid/existing.pdf",
+            storage_path=f"uploads/{_FAMILY_ID}/existing.pdf",
             original_filename="test.pdf",
             mime_type="application/pdf",
         )
@@ -116,9 +120,9 @@ class TestUploadDocument:
         # GCS アップロードや Cloud Tasks エンキューは呼ばれない
         mock_doc_repo.create.assert_not_called()
 
-    def test_upload_rate_limit_free_plan(self, client, mock_user_repo):
+    def test_upload_rate_limit_free_plan(self, client, mock_family_repo):
         """無料プランの月 5 枚制限を超えると 402 を返す"""
-        mock_user_repo.get_user.return_value = {
+        mock_family_repo.get_family.return_value = {
             "plan": "free",
             "documents_this_month": 5,
         }
@@ -128,9 +132,9 @@ class TestUploadDocument:
         )
         assert response.status_code == 402
 
-    def test_upload_premium_no_limit(self, client, mock_user_repo):
+    def test_upload_premium_no_limit(self, client, mock_family_repo):
         """プレミアムプランは枚数制限なし"""
-        mock_user_repo.get_user.return_value = {
+        mock_family_repo.get_family.return_value = {
             "plan": "premium",
             "documents_this_month": 100,
         }

--- a/tests/unit/test_api_families.py
+++ b/tests/unit/test_api_families.py
@@ -1,0 +1,178 @@
+"""FastAPI ファミリー API のユニットテスト
+
+dependency_overrides を使ってリポジトリをモックに差し替える。
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+from v2.entrypoints.api.app import app
+from v2.entrypoints.api.deps import (
+    FamilyContext,
+    get_family_context,
+    get_family_repo,
+    get_user_config_repo,
+    require_owner,
+)
+
+_UID = "test-owner-uid"
+_FAMILY_ID = "test-family-id"
+_OWNER_CONTEXT = FamilyContext(uid=_UID, family_id=_FAMILY_ID, role="owner")
+_MEMBER_CONTEXT = FamilyContext(uid="member-uid", family_id=_FAMILY_ID, role="member")
+
+
+@pytest.fixture
+def mock_family_repo():
+    repo = MagicMock()
+    repo.get_family.return_value = {
+        "name": "田中家",
+        "plan": "free",
+        "documents_this_month": 3,
+        "owner_uid": _UID,
+    }
+    repo.list_members.return_value = [
+        {
+            "uid": _UID,
+            "role": "owner",
+            "display_name": "パパ",
+            "email": "papa@example.com",
+        }
+    ]
+    repo.create_invitation.return_value = "inv-test-id"
+    repo.get_invitation_by_token.return_value = None
+    return repo
+
+
+@pytest.fixture
+def mock_user_repo():
+    repo = MagicMock()
+    repo.get_user.return_value = {"email": "papa@example.com", "display_name": "パパ"}
+    return repo
+
+
+@pytest.fixture
+def owner_client(mock_family_repo, mock_user_repo):
+    """オーナー権限のテストクライアント"""
+    app.dependency_overrides[get_family_context] = lambda: _OWNER_CONTEXT
+    app.dependency_overrides[require_owner] = lambda: _OWNER_CONTEXT
+    app.dependency_overrides[get_family_repo] = lambda: mock_family_repo
+    app.dependency_overrides[get_user_config_repo] = lambda: mock_user_repo
+
+    with TestClient(app) as c:
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def member_client(mock_family_repo, mock_user_repo):
+    """メンバー権限のテストクライアント（招待ができないケース用）"""
+    app.dependency_overrides[get_family_context] = lambda: _MEMBER_CONTEXT
+    app.dependency_overrides[require_owner] = _raise_forbidden
+    app.dependency_overrides[get_family_repo] = lambda: mock_family_repo
+    app.dependency_overrides[get_user_config_repo] = lambda: mock_user_repo
+
+    with TestClient(app) as c:
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+def _raise_forbidden():
+    from fastapi import HTTPException, status
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="この操作にはオーナー権限が必要です。",
+    )
+
+
+class TestGetMyFamily:
+    """GET /api/families/me のテスト"""
+
+    def test_returns_family_info(self, owner_client):
+        """ファミリー情報を返す"""
+        response = owner_client.get("/api/families/me")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == _FAMILY_ID
+        assert data["name"] == "田中家"
+        assert data["plan"] == "free"
+        assert data["role"] == "owner"
+
+    def test_returns_404_if_family_not_found(self, owner_client, mock_family_repo):
+        """ファミリーが存在しない場合は 404 を返す"""
+        mock_family_repo.get_family.return_value = None
+        response = owner_client.get("/api/families/me")
+        assert response.status_code == 404
+
+
+class TestListMembers:
+    """GET /api/families/members のテスト"""
+
+    def test_returns_member_list(self, owner_client):
+        """メンバー一覧を返す"""
+        response = owner_client.get("/api/families/members")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["uid"] == _UID
+        assert data[0]["role"] == "owner"
+
+    def test_member_can_list_members(self, member_client):
+        """メンバーもメンバー一覧を参照できる"""
+        response = member_client.get("/api/families/members")
+        assert response.status_code == 200
+
+
+class TestInviteMember:
+    """POST /api/families/invite のテスト"""
+
+    def test_owner_can_invite(self, owner_client, mock_family_repo):
+        """オーナーは招待できる"""
+        response = owner_client.post(
+            "/api/families/invite",
+            json={"email": "mama@example.com"},
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert "invitation_id" in data
+        assert "invite_url" in data
+
+    def test_member_cannot_invite(self, member_client):
+        """メンバーは招待できない（403 を返す）"""
+        response = member_client.post(
+            "/api/families/invite",
+            json={"email": "someone@example.com"},
+        )
+        assert response.status_code == 403
+
+
+class TestJoinFamily:
+    """POST /api/families/join のテスト"""
+
+    def test_invalid_token_returns_404(self, owner_client, mock_family_repo):
+        """無効なトークンは 404 を返す"""
+        mock_family_repo.get_invitation_by_token.return_value = None
+        response = owner_client.post(
+            "/api/families/join",
+            json={"token": "invalid-token"},
+        )
+        assert response.status_code == 404
+
+    def test_already_accepted_invitation_returns_400(
+        self, owner_client, mock_family_repo
+    ):
+        """使用済み招待は 400 を返す"""
+        mock_family_repo.get_invitation_by_token.return_value = {
+            "id": "inv-id",
+            "family_id": "other-family-id",
+            "status": "accepted",
+            "token": "some-token",
+        }
+        response = owner_client.post(
+            "/api/families/join",
+            json={"token": "some-token"},
+        )
+        assert response.status_code == 400

--- a/v2/domain/models.py
+++ b/v2/domain/models.py
@@ -97,6 +97,27 @@ class UserProfile:
 
 
 @dataclass(frozen=True)
+class FamilyMember:
+    """ファミリーメンバー"""
+
+    uid: str  # Firebase Auth UID
+    role: str  # "owner" | "member"
+    display_name: str
+    email: str
+
+
+@dataclass(frozen=True)
+class Invitation:
+    """ファミリー招待"""
+
+    id: str  # Firestore ドキュメントID
+    email: str  # 招待先メールアドレス
+    token: str  # UUID v4（URLに埋め込む）
+    status: str  # "pending" | "accepted" | "expired"
+    invited_by_uid: str
+
+
+@dataclass(frozen=True)
 class FileInfo:
     """Google Driveファイル情報"""
 

--- a/v2/domain/ports.py
+++ b/v2/domain/ports.py
@@ -184,11 +184,11 @@ class DocumentRepository(ABC):
 
 
 class UserConfigRepository(ABC):
-    """ユーザー設定・プロファイルの永続化（Firestore等）"""
+    """ユーザー個人設定の永続化（Firestore等）"""
 
     @abstractmethod
     def get_user(self, uid: str) -> dict:
-        """ユーザー設定を取得（plan, documentsThisMonth, icalToken等）"""
+        """ユーザー設定を取得（icalToken, notification_preferences等）"""
         pass
 
     @abstractmethod
@@ -196,23 +196,83 @@ class UserConfigRepository(ABC):
         """ユーザー設定を更新"""
         pass
 
+
+class FamilyRepository(ABC):
+    """ファミリー・プロファイルの永続化（Firestore等）"""
+
     @abstractmethod
-    def list_profiles(self, uid: str) -> list[UserProfile]:
-        """ユーザーのプロファイル一覧を取得"""
+    def create_family(self, family_id: str, owner_uid: str, name: str) -> None:
+        """ファミリーを作成"""
         pass
 
     @abstractmethod
-    def create_profile(self, uid: str, profile: UserProfile) -> str:
+    def get_family(self, family_id: str) -> dict | None:
+        """ファミリー設定を取得（plan, documents_this_month等）"""
+        pass
+
+    @abstractmethod
+    def update_family(self, family_id: str, data: dict) -> None:
+        """ファミリー設定を更新"""
+        pass
+
+    @abstractmethod
+    def add_member(
+        self, family_id: str, uid: str, role: str, display_name: str, email: str
+    ) -> None:
+        """ファミリーにメンバーを追加"""
+        pass
+
+    @abstractmethod
+    def remove_member(self, family_id: str, uid: str) -> None:
+        """ファミリーからメンバーを削除"""
+        pass
+
+    @abstractmethod
+    def list_members(self, family_id: str) -> list[dict]:
+        """メンバー一覧を取得"""
+        pass
+
+    @abstractmethod
+    def get_member_role(self, family_id: str, uid: str) -> str | None:
+        """メンバーのロールを取得。未参加の場合はNoneを返す"""
+        pass
+
+    @abstractmethod
+    def create_invitation(
+        self, family_id: str, email: str, invited_by_uid: str, token: str
+    ) -> str:
+        """招待を作成。生成されたIDを返す"""
+        pass
+
+    @abstractmethod
+    def get_invitation_by_token(self, token: str) -> dict | None:
+        """招待トークンで招待情報を取得"""
+        pass
+
+    @abstractmethod
+    def accept_invitation(self, invitation_id: str, family_id: str) -> None:
+        """招待ステータスを accepted に更新"""
+        pass
+
+    @abstractmethod
+    def list_profiles(self, family_id: str) -> list[UserProfile]:
+        """ファミリーのプロファイル一覧を取得"""
+        pass
+
+    @abstractmethod
+    def create_profile(self, family_id: str, profile: UserProfile) -> str:
         """プロファイルを作成。生成されたIDを返す"""
         pass
 
     @abstractmethod
-    def update_profile(self, uid: str, profile_id: str, profile: UserProfile) -> None:
+    def update_profile(
+        self, family_id: str, profile_id: str, profile: UserProfile
+    ) -> None:
         """プロファイルを更新"""
         pass
 
     @abstractmethod
-    def delete_profile(self, uid: str, profile_id: str) -> None:
+    def delete_profile(self, family_id: str, profile_id: str) -> None:
         """プロファイルを削除"""
         pass
 

--- a/v2/entrypoints/api/app.py
+++ b/v2/entrypoints/api/app.py
@@ -32,6 +32,7 @@ from v2.entrypoints import worker
 from v2.entrypoints.api.routes import (
     documents,
     events,
+    families,
     ical,
     profiles,
     settings,
@@ -73,6 +74,7 @@ app.include_router(documents.router, prefix=_PREFIX)
 app.include_router(events.router, prefix=_PREFIX)
 app.include_router(tasks.router, prefix=_PREFIX)
 app.include_router(profiles.router, prefix=_PREFIX)
+app.include_router(families.router, prefix=_PREFIX)
 app.include_router(ical.router, prefix=_PREFIX)
 app.include_router(settings.router, prefix=_PREFIX)
 

--- a/v2/entrypoints/api/routes/events.py
+++ b/v2/entrypoints/api/routes/events.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
 from v2.adapters.firestore_repository import FirestoreDocumentRepository
-from v2.entrypoints.api.deps import get_current_uid, get_document_repo
+from v2.entrypoints.api.deps import FamilyContext, get_document_repo, get_family_context
 
 router = APIRouter(prefix="/events", tags=["events"])
 
@@ -28,7 +28,7 @@ async def list_events(
     from_date: str | None = None,
     to_date: str | None = None,
     profile_id: str | None = None,
-    uid: str = Depends(get_current_uid),
+    ctx: FamilyContext = Depends(get_family_context),
     doc_repo: FirestoreDocumentRepository = Depends(get_document_repo),
 ) -> list[EventResponse]:
     """
@@ -40,7 +40,7 @@ async def list_events(
         profile_id: プロファイルでフィルター（未実装: 将来拡張）
     """
     events = doc_repo.list_events(
-        uid, from_date=from_date, to_date=to_date, profile_id=profile_id
+        ctx.family_id, from_date=from_date, to_date=to_date, profile_id=profile_id
     )
     return [
         EventResponse(

--- a/v2/entrypoints/api/routes/families.py
+++ b/v2/entrypoints/api/routes/families.py
@@ -1,0 +1,241 @@
+"""ファミリー管理 API ルート
+
+POST   /api/families           → 201 { id, name, role }
+GET    /api/families/me        → 200 { id, name, plan, ... }
+GET    /api/families/members   → 200 [{ uid, role, display_name, email }...]
+POST   /api/families/invite    → 201 { invitation_id, invite_url } （Phase 2）
+POST   /api/families/join      → 200 { family_id, name, role }   （Phase 2）
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from v2.adapters.firestore_repository import (
+    FirestoreFamilyRepository,
+    FirestoreUserConfigRepository,
+)
+from v2.entrypoints.api.deps import (
+    FamilyContext,
+    get_family_context,
+    get_family_repo,
+    get_user_config_repo,
+    require_owner,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/families", tags=["families"])
+
+
+# ── レスポンスモデル ─────────────────────────────────────────────────────────────
+
+
+class FamilyCreateRequest(BaseModel):
+    name: str = "マイファミリー"
+
+
+class FamilyResponse(BaseModel):
+    id: str
+    name: str
+    plan: str
+    documents_this_month: int
+    role: str
+
+
+class MemberResponse(BaseModel):
+    uid: str
+    role: str
+    display_name: str
+    email: str
+
+
+class InviteRequest(BaseModel):
+    email: str
+
+
+class InviteResponse(BaseModel):
+    invitation_id: str
+    invite_url: str
+
+
+class JoinRequest(BaseModel):
+    token: str
+
+
+class JoinResponse(BaseModel):
+    family_id: str
+    name: str
+    role: str
+
+
+# ── エンドポイント ────────────────────────────────────────────────────────────────
+
+
+@router.post("", status_code=status.HTTP_201_CREATED, response_model=FamilyResponse)
+async def create_family(
+    body: FamilyCreateRequest,
+    ctx: FamilyContext = Depends(get_family_context),
+    family_repo: FirestoreFamilyRepository = Depends(get_family_repo),
+) -> FamilyResponse:
+    """
+    ファミリーを作成する。
+
+    注意: get_family_context() が初回アクセス時に自動でファミリーを作成するため、
+    このエンドポイントはファミリー名を変更する目的で使用する。
+    """
+    family_repo.update_family(ctx.family_id, {"name": body.name})
+    logger.info("Family name updated: family_id=%s, name=%s", ctx.family_id, body.name)
+
+    family = family_repo.get_family(ctx.family_id) or {}
+    return FamilyResponse(
+        id=ctx.family_id,
+        name=family.get("name", body.name),
+        plan=family.get("plan", "free"),
+        documents_this_month=family.get("documents_this_month", 0),
+        role=ctx.role,
+    )
+
+
+@router.get("/me", response_model=FamilyResponse)
+async def get_my_family(
+    ctx: FamilyContext = Depends(get_family_context),
+    family_repo: FirestoreFamilyRepository = Depends(get_family_repo),
+) -> FamilyResponse:
+    """自分のファミリー情報を返す"""
+    family = family_repo.get_family(ctx.family_id)
+    if family is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Family not found"
+        )
+    return FamilyResponse(
+        id=ctx.family_id,
+        name=family.get("name", "マイファミリー"),
+        plan=family.get("plan", "free"),
+        documents_this_month=family.get("documents_this_month", 0),
+        role=ctx.role,
+    )
+
+
+@router.get("/members", response_model=list[MemberResponse])
+async def list_members(
+    ctx: FamilyContext = Depends(get_family_context),
+    family_repo: FirestoreFamilyRepository = Depends(get_family_repo),
+) -> list[MemberResponse]:
+    """ファミリーメンバー一覧を返す"""
+    members = family_repo.list_members(ctx.family_id)
+    return [
+        MemberResponse(
+            uid=m.get("uid", ""),
+            role=m.get("role", "member"),
+            display_name=m.get("display_name", ""),
+            email=m.get("email", ""),
+        )
+        for m in members
+    ]
+
+
+@router.post(
+    "/invite", status_code=status.HTTP_201_CREATED, response_model=InviteResponse
+)
+async def invite_member(
+    body: InviteRequest,
+    ctx: FamilyContext = Depends(require_owner),
+    family_repo: FirestoreFamilyRepository = Depends(get_family_repo),
+) -> InviteResponse:
+    """
+    メンバーを招待する（オーナーのみ）。
+
+    招待トークンを含む URL を生成する。
+    招待先はこの URL にアクセスして POST /api/families/join を呼び出す。
+    """
+    import os
+
+    token = str(uuid.uuid4())
+    invitation_id = family_repo.create_invitation(
+        family_id=ctx.family_id,
+        email=body.email,
+        invited_by_uid=ctx.uid,
+        token=token,
+    )
+
+    api_base_url = os.environ.get("API_BASE_URL", "")
+    invite_url = f"{api_base_url}/invite?token={token}"
+
+    logger.info(
+        "Invitation created: family_id=%s, email=%s, invitation_id=%s",
+        ctx.family_id,
+        body.email,
+        invitation_id,
+    )
+    return InviteResponse(invitation_id=invitation_id, invite_url=invite_url)
+
+
+@router.post("/join", response_model=JoinResponse)
+async def join_family(
+    body: JoinRequest,
+    ctx: FamilyContext = Depends(get_family_context),
+    family_repo: FirestoreFamilyRepository = Depends(get_family_repo),
+    user_repo: FirestoreUserConfigRepository = Depends(get_user_config_repo),
+) -> JoinResponse:
+    """
+    招待トークンを使ってファミリーに参加する。
+
+    1. トークンで招待情報を取得
+    2. 有効な招待（pending かつ期限内）であることを確認
+    3. 現在のファミリーを離れて新しいファミリーに参加
+    4. users/{uid} の family_id を更新
+    """
+    import datetime
+
+    invitation = family_repo.get_invitation_by_token(body.token)
+    if invitation is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Invalid invitation token"
+        )
+
+    if invitation.get("status") != "pending":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="この招待はすでに使用済みまたは期限切れです。",
+        )
+
+    expires_at = invitation.get("expires_at")
+    if expires_at and expires_at < datetime.datetime.now(datetime.UTC):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="招待の有効期限が切れています。",
+        )
+
+    new_family_id = invitation["family_id"]
+    new_family = family_repo.get_family(new_family_id)
+    if new_family is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Family not found"
+        )
+
+    # メンバーとして追加
+    user = user_repo.get_user(ctx.uid)
+    family_repo.add_member(
+        family_id=new_family_id,
+        uid=ctx.uid,
+        role="member",
+        display_name=user.get("display_name", user.get("email", ctx.uid)),
+        email=user.get("email", ""),
+    )
+
+    # users/{uid} の family_id を更新
+    user_repo.update_user(ctx.uid, {"family_id": new_family_id})
+
+    # 招待を accepted に更新
+    family_repo.accept_invitation(invitation["id"], new_family_id)
+
+    logger.info("User joined family: uid=%s, family_id=%s", ctx.uid, new_family_id)
+    return JoinResponse(
+        family_id=new_family_id,
+        name=new_family.get("name", "マイファミリー"),
+        role="member",
+    )

--- a/v2/entrypoints/api/routes/profiles.py
+++ b/v2/entrypoints/api/routes/profiles.py
@@ -13,9 +13,9 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 
-from v2.adapters.firestore_repository import FirestoreUserConfigRepository
+from v2.adapters.firestore_repository import FirestoreFamilyRepository
 from v2.domain.models import UserProfile
-from v2.entrypoints.api.deps import get_current_uid, get_user_config_repo
+from v2.entrypoints.api.deps import FamilyContext, get_family_context, get_family_repo
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/profiles", tags=["profiles"])
@@ -36,11 +36,11 @@ class ProfileResponse(BaseModel):
 
 @router.get("", response_model=list[ProfileResponse])
 async def list_profiles(
-    uid: str = Depends(get_current_uid),
-    repo: FirestoreUserConfigRepository = Depends(get_user_config_repo),
+    ctx: FamilyContext = Depends(get_family_context),
+    repo: FirestoreFamilyRepository = Depends(get_family_repo),
 ) -> list[ProfileResponse]:
     """プロファイル一覧を返す"""
-    profiles = repo.list_profiles(uid)
+    profiles = repo.list_profiles(ctx.family_id)
     return [
         ProfileResponse(id=p.id, name=p.name, grade=p.grade, keywords=p.keywords)
         for p in profiles
@@ -50,15 +50,17 @@ async def list_profiles(
 @router.post("", status_code=status.HTTP_201_CREATED, response_model=ProfileResponse)
 async def create_profile(
     body: ProfileRequest,
-    uid: str = Depends(get_current_uid),
-    repo: FirestoreUserConfigRepository = Depends(get_user_config_repo),
+    ctx: FamilyContext = Depends(get_family_context),
+    repo: FirestoreFamilyRepository = Depends(get_family_repo),
 ) -> ProfileResponse:
     """プロファイルを作成する"""
     profile = UserProfile(
         id="", name=body.name, grade=body.grade, keywords=body.keywords
     )
-    profile_id = repo.create_profile(uid, profile)
-    logger.info("Profile created: uid=%s, profile_id=%s", uid, profile_id)
+    profile_id = repo.create_profile(ctx.family_id, profile)
+    logger.info(
+        "Profile created: family_id=%s, profile_id=%s", ctx.family_id, profile_id
+    )
     return ProfileResponse(
         id=profile_id, name=body.name, grade=body.grade, keywords=body.keywords
     )
@@ -68,12 +70,11 @@ async def create_profile(
 async def update_profile(
     profile_id: str,
     body: ProfileRequest,
-    uid: str = Depends(get_current_uid),
-    repo: FirestoreUserConfigRepository = Depends(get_user_config_repo),
+    ctx: FamilyContext = Depends(get_family_context),
+    repo: FirestoreFamilyRepository = Depends(get_family_repo),
 ) -> ProfileResponse:
     """プロファイルを更新する"""
-    # 存在確認
-    profiles = repo.list_profiles(uid)
+    profiles = repo.list_profiles(ctx.family_id)
     if not any(p.id == profile_id for p in profiles):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Profile not found"
@@ -82,8 +83,10 @@ async def update_profile(
     profile = UserProfile(
         id=profile_id, name=body.name, grade=body.grade, keywords=body.keywords
     )
-    repo.update_profile(uid, profile_id, profile)
-    logger.info("Profile updated: uid=%s, profile_id=%s", uid, profile_id)
+    repo.update_profile(ctx.family_id, profile_id, profile)
+    logger.info(
+        "Profile updated: family_id=%s, profile_id=%s", ctx.family_id, profile_id
+    )
     return ProfileResponse(
         id=profile_id, name=body.name, grade=body.grade, keywords=body.keywords
     )
@@ -92,14 +95,16 @@ async def update_profile(
 @router.delete("/{profile_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_profile(
     profile_id: str,
-    uid: str = Depends(get_current_uid),
-    repo: FirestoreUserConfigRepository = Depends(get_user_config_repo),
+    ctx: FamilyContext = Depends(get_family_context),
+    repo: FirestoreFamilyRepository = Depends(get_family_repo),
 ) -> None:
     """プロファイルを削除する"""
-    profiles = repo.list_profiles(uid)
+    profiles = repo.list_profiles(ctx.family_id)
     if not any(p.id == profile_id for p in profiles):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Profile not found"
         )
-    repo.delete_profile(uid, profile_id)
-    logger.info("Profile deleted: uid=%s, profile_id=%s", uid, profile_id)
+    repo.delete_profile(ctx.family_id, profile_id)
+    logger.info(
+        "Profile deleted: family_id=%s, profile_id=%s", ctx.family_id, profile_id
+    )

--- a/v2/entrypoints/api/routes/settings.py
+++ b/v2/entrypoints/api/routes/settings.py
@@ -13,8 +13,16 @@ import uuid
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
-from v2.adapters.firestore_repository import FirestoreUserConfigRepository
-from v2.entrypoints.api.deps import get_current_uid, get_user_config_repo
+from v2.adapters.firestore_repository import (
+    FirestoreFamilyRepository,
+    FirestoreUserConfigRepository,
+)
+from v2.entrypoints.api.deps import (
+    FamilyContext,
+    get_family_context,
+    get_family_repo,
+    get_user_config_repo,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/settings", tags=["settings"])
@@ -37,24 +45,27 @@ class SettingsUpdateRequest(BaseModel):
 
 @router.get("", response_model=SettingsResponse)
 async def get_settings(
-    uid: str = Depends(get_current_uid),
-    repo: FirestoreUserConfigRepository = Depends(get_user_config_repo),
+    ctx: FamilyContext = Depends(get_family_context),
+    user_repo: FirestoreUserConfigRepository = Depends(get_user_config_repo),
+    family_repo: FirestoreFamilyRepository = Depends(get_family_repo),
 ) -> SettingsResponse:
     """ユーザー設定を返す"""
-    user = repo.get_user(uid)
+    user = user_repo.get_user(ctx.uid)
+    family = family_repo.get_family(ctx.family_id) or {}
 
-    # icalToken が未設定の場合は初期化
+    # icalToken が未設定の場合は初期化（個人単位）
     ical_token = user.get("ical_token")
     if not ical_token:
         ical_token = str(uuid.uuid4())
-        repo.update_user(uid, {"ical_token": ical_token})
+        user_repo.update_user(ctx.uid, {"ical_token": ical_token})
 
     ical_url = f"{_API_BASE_URL}/api/ical/{ical_token}"
 
+    # 通知設定は個人単位、課金情報はファミリー単位
     prefs = user.get("notification_preferences", {})
     return SettingsResponse(
-        plan=user.get("plan", "free"),
-        documents_this_month=user.get("documents_this_month", 0),
+        plan=family.get("plan", "free"),
+        documents_this_month=family.get("documents_this_month", 0),
         ical_url=ical_url,
         notification_email=prefs.get("email", True),
         notification_web_push=prefs.get("web_push", False),
@@ -64,8 +75,9 @@ async def get_settings(
 @router.patch("", response_model=SettingsResponse)
 async def update_settings(
     body: SettingsUpdateRequest,
-    uid: str = Depends(get_current_uid),
-    repo: FirestoreUserConfigRepository = Depends(get_user_config_repo),
+    ctx: FamilyContext = Depends(get_family_context),
+    user_repo: FirestoreUserConfigRepository = Depends(get_user_config_repo),
+    family_repo: FirestoreFamilyRepository = Depends(get_family_repo),
 ) -> SettingsResponse:
     """設定を部分更新する"""
     update: dict = {}
@@ -75,7 +87,7 @@ async def update_settings(
         update["notification_preferences.web_push"] = body.notification_web_push
 
     if update:
-        repo.update_user(uid, update)
-        logger.info("Settings updated: uid=%s, fields=%s", uid, list(update.keys()))
+        user_repo.update_user(ctx.uid, update)
+        logger.info("Settings updated: uid=%s, fields=%s", ctx.uid, list(update.keys()))
 
-    return await get_settings(uid=uid, repo=repo)
+    return await get_settings(ctx=ctx, user_repo=user_repo, family_repo=family_repo)


### PR DESCRIPTION
## Summary

- **ハイブリッドモデル採用**: 共有データを `families/{familyId}/` に、個人設定を `users/{uid}/` に分離し、マルチユーザーの家族共有を実現
- **family_id ベースのクエリ移行**: `DocumentRepository` / `EventData` / `TaskData` のクエリキーを `user_uid → family_id` に統一
- **家族管理 API 追加** (`routes/families.py`): `GET /me`, `GET /members`, `POST /invite`, `POST /join` などの招待フローを実装
- **Firestoreインデックス更新**: `events_by_start` / `tasks_by_completed` を `family_id` フィールドに変更、`invitations` collection_group インデックスを新規追加
- **Terraform import ブロック削除**: 旧 `user_uid` インデックスの import が destroy→recreate 時に競合するため削除
- **lint 修正**: 未使用 `Invitation` インポートを削除 (ruff F401)
- **移行スクリプト追加**: `scripts/migrate_to_families.py` — 既存データを family_id ベースに移行

## Test plan

- [ ] CI (lint + 88 ユニットテスト) がパスすること
- [ ] Terraform plan で `events_by_start` / `tasks_by_completed` インデックスの destroy→recreate と `invitations_by_token` インデックスの create が計画されること
- [ ] dev 環境デプロイ後: `GET /api/families/me` で自動ファミリー作成・情報取得が動作すること
- [ ] dev 環境デプロイ後: 既存エンドポイント (documents, events, tasks, profiles) が family_id ベースで正常動作すること
- [ ] dev 環境に既存データがある場合: `scripts/migrate_to_families.py` を実行してデータ移行

🤖 Generated with [Claude Code](https://claude.com/claude-code)