### PR TITLE
fix(terraform): invitations インデックスを複合→単一フィールドに修正

### DIFF
--- a/terraform/modules/firestore/main.tf
+++ b/terraform/modules/firestore/main.tf
@@ -56,21 +56,28 @@ resource "google_firestore_index" "tasks_by_completed" {
   depends_on = [google_firestore_database.this]
 }
 
-# 招待トークンで招待情報を検索するための collection_group インデックス
-resource "google_firestore_index" "invitations_by_token" {
-  project     = var.project_id
-  database    = google_firestore_database.this.name
-  collection  = "invitations"
-  query_scope = "COLLECTION_GROUP"
+# 招待トークンで invitations collection_group を検索するための単一フィールドインデックス
+# collection_group クエリには複合インデックスではなく google_firestore_field が必要
+resource "google_firestore_field" "invitations_token" {
+  project    = var.project_id
+  database   = google_firestore_database.this.name
+  collection = "invitations"
+  field      = "token"
 
-  fields {
-    field_path = "token"
-    order      = "ASCENDING"
-  }
-
-  fields {
-    field_path = "__name__"
-    order      = "ASCENDING"
+  # index_config を明示する場合はデフォルト（COLLECTION ASC/DESC）も含める必要がある
+  index_config {
+    indexes {
+      order       = "ASCENDING"
+      query_scope = "COLLECTION"
+    }
+    indexes {
+      order       = "DESCENDING"
+      query_scope = "COLLECTION"
+    }
+    indexes {
+      order       = "ASCENDING"
+      query_scope = "COLLECTION_GROUP"
+    }
   }
 
   depends_on = [google_firestore_database.this]


### PR DESCRIPTION
## Summary

- `google_firestore_index`（複合インデックス）で `token` + `__name__` を指定したところ、Firestore API が **Error 400: this index is not necessary, configure using single field index controls** で拒否（CD dev #22438288645 で発覚）
- `google_firestore_field` リソースに変更し、`COLLECTION_GROUP` スコープの単一フィールドインデックスとして正しく定義
- `index_config` を明示する場合はデフォルトの COLLECTION ASC/DESC も含める必要があるため合わせて追加

## Root Cause

Firestoreの複合インデックス（`google_firestore_index`）は実データフィールドが2つ以上必要。`__name__` はシステムフィールドなので「1フィールド」と見なされ、単一フィールドインデックス設定（`google_firestore_field`）での設定を要求される。

## Test plan

- [ ] CI (lint + テスト) がパスすること
- [ ] Terraform plan で `google_firestore_field.invitations_token` の create が計画されること
- [ ] dev 環境デプロイ後: `POST /api/families/invite` → `POST /api/families/join` の招待フローが動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)