### PR TITLE
fix(family): メンバー表示名が UID になる問題を修正

### DIFF
--- a/v2/adapters/firestore_repository.py
+++ b/v2/adapters/firestore_repository.py
@@ -446,6 +446,12 @@ class FirestoreFamilyRepository(FamilyRepository):
         )
         logger.info("Added member: family_id=%s, uid=%s, role=%s", family_id, uid, role)
 
+    def update_member(self, family_id: str, uid: str, updates: dict) -> None:
+        """メンバーの属性を部分更新"""
+        self._db.collection(_FAMILIES).document(family_id).collection(
+            _MEMBERS
+        ).document(uid).update(updates)
+
     def remove_member(self, family_id: str, uid: str) -> None:
         """ファミリーからメンバーを削除"""
         self._db.collection(_FAMILIES).document(family_id).collection(

--- a/v2/entrypoints/api/deps.py
+++ b/v2/entrypoints/api/deps.py
@@ -194,6 +194,12 @@ async def get_family_context(
         logger.info("Auto-created family: uid=%s, family_id=%s", uid, family_id)
 
     role = family_repo.get_member_role(family_id, uid) or "member"
+
+    # JWT から同期した email/display_name をメンバーエントリにも反映
+    # （招待参加時に users/{uid} が空だった既存メンバーの display_name/email を補完）
+    if updates:
+        family_repo.update_member(family_id, uid, updates)
+
     return FamilyContext(uid=uid, family_id=family_id, role=role)
 
 


### PR DESCRIPTION
## 問題

招待参加時に `users/{uid}` に `email`/`display_name` がない状態でファミリーに参加すると、
`families/.../members/{uid}` のエントリも空のまま登録されてしまい、
設定ページのメンバー一覧に Firebase UID が表示されていた。

## 原因

`get_family_context()` は JWT から `email`/`display_name` を `users/{uid}` に同期するが、
メンバー一覧が読む `families/{familyId}/members/{uid}` エントリは更新していなかった。

## 修正内容

- `FirestoreFamilyRepository.update_member()` を追加（部分更新用）
- `get_family_context()` で JWT 同期が発生した場合、メンバーエントリにも同じ内容を反映
  → 次回 API アクセス時（ログイン後最初のリクエスト）に自動で表示名が補完される

## Test plan

- [ ] CI (lint / test / e2e) が全パスすること
- [ ] 既存メンバーが API にアクセスすると、メンバー一覧の表示名が UID → メールアドレス/名前に更新されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)