### PR TITLE
fix: member エントリの display_name/email 同期条件を修正

### DIFF
--- a/v2/adapters/firestore_repository.py
+++ b/v2/adapters/firestore_repository.py
@@ -469,8 +469,8 @@ class FirestoreFamilyRepository(FamilyRepository):
         )
         return [{"uid": snap.id, **(snap.to_dict() or {})} for snap in snaps]
 
-    def get_member_role(self, family_id: str, uid: str) -> str | None:
-        """メンバーのロールを取得。未参加の場合はNoneを返す"""
+    def get_member(self, family_id: str, uid: str) -> dict | None:
+        """メンバーの全データを取得。未参加の場合はNoneを返す"""
         snap = (
             self._db.collection(_FAMILIES)
             .document(family_id)
@@ -480,7 +480,14 @@ class FirestoreFamilyRepository(FamilyRepository):
         )
         if not snap.exists:
             return None
-        return (snap.to_dict() or {}).get("role")
+        return snap.to_dict() or {}
+
+    def get_member_role(self, family_id: str, uid: str) -> str | None:
+        """メンバーのロールを取得。未参加の場合はNoneを返す"""
+        member = self.get_member(family_id, uid)
+        if member is None:
+            return None
+        return member.get("role")
 
     # ── 招待管理 ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- `get_family_context()` で member エントリの `email`/`display_name` が空の場合でも `users/{uid}` の値で正しく補完されない問題を修正
- PR #57 の修正条件「`if updates:`」が不完全だった: `users/{uid}` に既にデータがある場合、`updates` が空になり `update_member` が呼ばれなかった

## Root Cause

```
PR #55: users/{uid} に email/display_name を同期  ← 完了
PR #57: members/{uid} の同期条件 = "if updates:" 
        → users/{uid} が既に同期済みの場合 updates={} → member 未更新  ← バグ
```

## Fix

- `firestore_repository.py`: `get_member()` メソッドを追加（member エントリ全データ取得）、`get_member_role()` は `get_member()` に委譲
- `deps.py`: `get_member()` で member エントリ自体を読み込み、`email`/`display_name` を独立して空チェックして補完

```python
# 修正後: users/{uid} の同期有無に関わらず member エントリを個別に補完
member_data = family_repo.get_member(family_id, uid)
if member_data:
    member_updates = {}
    if not member_data.get("email") and user_data.get("email"):
        member_updates["email"] = user_data["email"]
    if not member_data.get("display_name") and user_data.get("display_name"):
        member_updates["display_name"] = user_data["display_name"]
    if member_updates:
        family_repo.update_member(family_id, uid, member_updates)
```

## Test plan

- [ ] `uv run pytest tests/unit/ -v` (88件全パス確認済み)
- [ ] CI が通ることを確認
- [ ] 本番デプロイ後、設定ページでメンバー名が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)