### PR TITLE
feat: ファイルアップロードのサイズ・ページ数制限を追加 (closes #64)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ __pycache__
 # Test samples (local only)
 sample/
 
+# Manual test fixtures: 大容量ファイルはスクリプト実行時に生成するため除外
+tests/manual/fixtures/over_limit_*.bin
+
 # takt tool internals
 .takt/.runtime/
 .takt/runs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ dependencies = [
     "pywebpush>=2.0.0",
     # --- リトライ ---
     "tenacity>=9.0.0",
+    # --- PDF 解析 ---
+    "pypdf>=4.0.0",
     # --- ユーティリティ ---
     "python-dotenv>=1.2.1",
     "slack-sdk>=3.39.0",

--- a/tests/manual/UPLOAD_VALIDATION_GUIDE.md
+++ b/tests/manual/UPLOAD_VALIDATION_GUIDE.md
@@ -1,0 +1,162 @@
+# アップロードバリデーション 手動検証ガイド
+
+Issue #64 で追加したファイルサイズ・PDF ページ数制限が、デプロイ後の dev 環境で
+正常に動作しているかを確認するための手順書。
+
+---
+
+## 検証シナリオ
+
+| # | シナリオ | 使用ファイル | 期待レスポンス |
+|---|---------|------------|-------------|
+| 1 | 通常 PDF（1ページ） | `fixtures/valid_1page.pdf` | **202** Accepted |
+| 2 | サイズ超過（11MB） | スクリプト内で生成 | **413** Too Large |
+| 3 | ページ数超過（4ページ） | `fixtures/over_limit_4page.pdf` | **422** Unprocessable |
+| 4 | 破損 PDF | `fixtures/corrupted.pdf` | **422** Unprocessable |
+
+> **注意**: デフォルトのページ数上限は **3ページ**、サイズ上限は **10MB**。
+> 環境変数 `MAX_PDF_PAGES` / `MAX_UPLOAD_SIZE_MB` で変更可能。
+
+---
+
+## 事前準備
+
+### 1. Firebase ID トークンの取得
+
+トークンは **1時間** で失効するので、検証直前に取得すること。
+
+このアプリは Firebase SDK v9（モジュール型）を使っており、`firebase` グローバル変数は
+存在しない。**Network タブから取得するのが最も確実**。
+
+#### Network タブから取得（推奨）
+
+1. dev 環境のアプリをブラウザで開き、ログインする
+2. DevTools を開く（F12）→ **Network** タブ
+3. ダッシュボードなど `/api/` へのリクエストが発生するページに移動する
+4. Network タブの一覧から `/api/documents` や `/api/families/me` などのリクエストをクリック
+5. **Headers** タブ → **Request Headers** セクションの `Authorization` 行を確認
+6. `Bearer eyJhbGci...` の `Bearer ` より後をコピーする（`eyJ` で始まる長い文字列）
+
+```
+Authorization: Bearer eyJhbGciOiJSUzI1NiIsImtp...  ← ここの Bearer 以降をコピー
+```
+
+#### Console から取得（代替手段）
+
+Firebase SDK v9 のモジュールは console から直接アクセスできないが、
+以下のように Next.js の内部モジュールを経由することで取得できる場合がある:
+
+```javascript
+// ダッシュボードのページで試す（動作は Next.js のバンドル構成に依存）
+const { auth } = await import("/_next/static/chunks/src_lib_firebase_ts.js");
+await auth.currentUser?.getIdToken();
+```
+
+> **それでも取れない場合**: Network タブの方法を使う。Console アプローチは
+> バンドルのキャッシュ名が変わると使えなくなる。
+
+### 2. API URL の確認
+
+Cloud Run サービスの URL を確認する:
+
+```bash
+gcloud run services describe clearbag-api-dev \
+  --region asia-northeast1 \
+  --project clearbag-dev \
+  --format "value(status.url)"
+```
+
+---
+
+## スクリプトによる自動検証
+
+```bash
+# dev 環境に対して実行
+API_URL=https://api-xxxxxxxxxx-an.a.run.app \
+FIREBASE_TOKEN=eyJhbGciO... \
+uv run python tests/manual/test_upload_validation.py
+```
+
+### 期待される出力
+
+```
+=======================================================
+  アップロードバリデーション 手動検証
+=======================================================
+  API_URL     : https://api-xxxxxxxxxx-an.a.run.app
+  USE_FIXTURES: False
+  token       : eyJhbGciOiJSUzI1Ni...
+=======================================================
+
+[1/4] 通常 PDF (1ページ, ~1KB) → 202 期待
+  ✅ status=202  期待=202
+     → doc_id=xxxxxxxx-xxxx を削除しました（クリーンアップ）
+
+[2/4] サイズ超過 (11MB) → 413 期待
+  （11MB ダミーファイルをメモリ上で生成中...）
+  ✅ status=413  期待=413
+
+[3/4] ページ数超過 (4ページ) → 422 期待
+  ✅ status=422  期待=422
+
+[4/4] 破損 PDF → 422 期待
+  ✅ status=422  期待=422
+
+=======================================================
+  ✅ 全シナリオ通過: 4/4
+=======================================================
+```
+
+### 失敗した場合
+
+シナリオ 2〜4 が **202 を返している** 場合 → バリデーション実装がデプロイされていない可能性。
+Cloud Run のイメージバージョンを確認:
+
+```bash
+gcloud run services describe clearbag-api-dev \
+  --region asia-northeast1 \
+  --project clearbag-dev \
+  --format "value(spec.template.spec.containers[0].image)"
+```
+
+### オプション
+
+```bash
+# fixtures/ の実ファイルを使いたい場合
+USE_FIXTURES=1 API_URL=... FIREBASE_TOKEN=... uv run python tests/manual/test_upload_validation.py
+
+# シナリオ1で登録されたドキュメントを削除しない場合
+DISABLE_CLEANUP=1 API_URL=... FIREBASE_TOKEN=... uv run python tests/manual/test_upload_validation.py
+```
+
+---
+
+## ブラウザ UI での手動確認
+
+`fixtures/` に UI でドラッグ&ドロップして確認できるファイルを用意している。
+
+| ファイル | 使い方 |
+|---------|--------|
+| `fixtures/valid_1page.pdf` | 通常アップロード → 成功することを確認 |
+| `fixtures/valid_3page.pdf` | ページ数上限ぴったり → 成功することを確認 |
+| `fixtures/over_limit_4page.pdf` | ページ数超過 → エラーメッセージ表示を確認 |
+| `fixtures/corrupted.pdf` | 破損ファイル → エラーメッセージ表示を確認 |
+
+> **11MB 超のファイル確認**: ブラウザで大きなファイルを試すには、以下で生成したものを使う:
+> ```bash
+> # 11MB のダミーファイルを生成（git には含めない）
+> python -c "open('tests/manual/fixtures/over_limit_11mb.bin', 'wb').write(b'\\x00' * (11 * 1024 * 1024))"
+> ```
+> クライアント側でブロックされるため、サーバーにリクエストは飛ばない。
+
+---
+
+## デプロイ前後の挙動比較
+
+| | デプロイ前（旧コード） | デプロイ後（新コード） |
+|--|---------------------|---------------------|
+| 11MB PDF | 202（制限なし） | **413** |
+| 4ページ PDF | 202（制限なし） | **422** |
+| 破損 PDF | 202 or 500 | **422** |
+
+> **「今やると全部通っちゃう」** のはこのため。デプロイ後に実行すること。

--- a/tests/manual/fixtures/corrupted.pdf
+++ b/tests/manual/fixtures/corrupted.pdf
@@ -1,0 +1,3 @@
+%PDF-1.4
+%%EOF
+this is corrupted garbage data that pypdf cannot parse

--- a/tests/manual/fixtures/over_limit_4page.pdf
+++ b/tests/manual/fixtures/over_limit_4page.pdf
@@ -1,0 +1,75 @@
+%PDF-1.3
+%‚„œ”
+1 0 obj
+<<
+/Producer (pypdf)
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Count 4
+/Kids [ 4 0 R 5 0 R 6 0 R 7 0 R ]
+>>
+endobj
+3 0 obj
+<<
+/Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0.0 0.0 595 842 ]
+/Parent 2 0 R
+>>
+endobj
+5 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0.0 0.0 595 842 ]
+/Parent 2 0 R
+>>
+endobj
+6 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0.0 0.0 595 842 ]
+/Parent 2 0 R
+>>
+endobj
+7 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0.0 0.0 595 842 ]
+/Parent 2 0 R
+>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000015 00000 n 
+0000000054 00000 n 
+0000000131 00000 n 
+0000000180 00000 n 
+0000000274 00000 n 
+0000000368 00000 n 
+0000000462 00000 n 
+trailer
+<<
+/Size 8
+/Root 3 0 R
+/Info 1 0 R
+>>
+startxref
+556
+%%EOF

--- a/tests/manual/fixtures/valid_1page.pdf
+++ b/tests/manual/fixtures/valid_1page.pdf
@@ -1,0 +1,45 @@
+%PDF-1.3
+%‚„œ”
+1 0 obj
+<<
+/Producer (pypdf)
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Count 1
+/Kids [ 4 0 R ]
+>>
+endobj
+3 0 obj
+<<
+/Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0.0 0.0 595 842 ]
+/Parent 2 0 R
+>>
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000015 00000 n 
+0000000054 00000 n 
+0000000113 00000 n 
+0000000162 00000 n 
+trailer
+<<
+/Size 5
+/Root 3 0 R
+/Info 1 0 R
+>>
+startxref
+256
+%%EOF

--- a/tests/manual/fixtures/valid_3page.pdf
+++ b/tests/manual/fixtures/valid_3page.pdf
@@ -1,0 +1,65 @@
+%PDF-1.3
+%‚„œ”
+1 0 obj
+<<
+/Producer (pypdf)
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Count 3
+/Kids [ 4 0 R 5 0 R 6 0 R ]
+>>
+endobj
+3 0 obj
+<<
+/Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0.0 0.0 595 842 ]
+/Parent 2 0 R
+>>
+endobj
+5 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0.0 0.0 595 842 ]
+/Parent 2 0 R
+>>
+endobj
+6 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0.0 0.0 595 842 ]
+/Parent 2 0 R
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000054 00000 n 
+0000000125 00000 n 
+0000000174 00000 n 
+0000000268 00000 n 
+0000000362 00000 n 
+trailer
+<<
+/Size 7
+/Root 3 0 R
+/Info 1 0 R
+>>
+startxref
+456
+%%EOF

--- a/tests/manual/test_upload_validation.py
+++ b/tests/manual/test_upload_validation.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+アップロードバリデーション 手動検証スクリプト
+
+デプロイ後の dev/prod 環境で、ファイルサイズ・PDF ページ数制限が
+正常に機能しているか確認する。
+
+検証シナリオ:
+  [1] 通常 PDF    (1ページ, ~1KB)   → 202 Accepted          ← 通ってほしい
+  [2] サイズ超過  (11MB ダミー)      → 413 Too Large         ← 弾いてほしい
+  [3] ページ数超過 (4ページ PDF)     → 422 Unprocessable     ← 弾いてほしい
+  [4] 破損 PDF    (不正バイト列)     → 422 Unprocessable     ← 弾いてほしい
+
+使い方:
+  API_URL=https://api.clearbag-dev.example.com \\
+  FIREBASE_TOKEN=eyJhbGciO... \\
+  uv run python tests/manual/test_upload_validation.py
+
+  # fixtures/ の実ファイルを使いたい場合:
+  USE_FIXTURES=1 \\
+  API_URL=https://... FIREBASE_TOKEN=... \\
+  uv run python tests/manual/test_upload_validation.py
+
+環境変数:
+  API_URL        - dev API のベース URL（末尾スラッシュなし）
+                   例: https://api-xxxxxxxxxxx-an.a.run.app
+  FIREBASE_TOKEN - Firebase ID トークン（取得手順は UPLOAD_VALIDATION_GUIDE.md 参照）
+  USE_FIXTURES   - 1 を指定すると tests/manual/fixtures/ のファイルを読み込んで使用
+  DISABLE_CLEANUP - 1 を指定すると 202 で登録したドキュメントを削除しない（デフォルト: 削除する）
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+import time
+from pathlib import Path
+
+import httpx
+from pypdf import PdfWriter
+
+# ───────────────────────────────────────────────
+# 設定
+# ───────────────────────────────────────────────
+API_URL = os.environ.get("API_URL", "").rstrip("/")
+FIREBASE_TOKEN = os.environ.get("FIREBASE_TOKEN", "")
+USE_FIXTURES = os.environ.get("USE_FIXTURES") == "1"
+DISABLE_CLEANUP = os.environ.get("DISABLE_CLEANUP") == "1"
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+PASS = "✅"
+FAIL = "❌"
+SKIP = "⏭️"
+
+
+# ───────────────────────────────────────────────
+# テストデータ生成
+# ───────────────────────────────────────────────
+
+def _make_pdf_bytes(num_pages: int) -> bytes:
+    """pypdf で num_pages ページの空白 PDF を生成する"""
+    writer = PdfWriter()
+    for _ in range(num_pages):
+        writer.add_blank_page(width=595, height=842)  # A4
+    buf = io.BytesIO()
+    writer.write(buf)
+    return buf.getvalue()
+
+
+def _load_or_generate(fixture_name: str, generator_fn) -> bytes:
+    """USE_FIXTURES=1 なら fixtures/ から読み込み、そうでなければ生成する"""
+    if USE_FIXTURES:
+        path = FIXTURES_DIR / fixture_name
+        if not path.exists():
+            print(f"  ⚠️  {path} が見つかりません。プログラム生成に切り替えます。")
+        else:
+            return path.read_bytes()
+    return generator_fn()
+
+
+# ───────────────────────────────────────────────
+# HTTP ヘルパー
+# ───────────────────────────────────────────────
+
+def _upload(client: httpx.Client, filename: str, content: bytes, mime_type: str) -> tuple[int, dict]:
+    resp = client.post(
+        f"{API_URL}/api/documents/upload",
+        files={"file": (filename, content, mime_type)},
+        timeout=30,
+    )
+    try:
+        body = resp.json()
+    except Exception:
+        body = {"raw": resp.text}
+    return resp.status_code, body
+
+
+def _delete(client: httpx.Client, doc_id: str) -> None:
+    try:
+        client.delete(f"{API_URL}/api/documents/{doc_id}", timeout=10)
+    except Exception:
+        pass
+
+
+# ───────────────────────────────────────────────
+# 各シナリオ
+# ───────────────────────────────────────────────
+
+def scenario_normal_pdf(client: httpx.Client) -> bool:
+    """[1] 通常 PDF (1ページ) → 202"""
+    content = _load_or_generate("valid_1page.pdf", lambda: _make_pdf_bytes(1))
+    status, body = _upload(client, "valid_1page.pdf", content, "application/pdf")
+    ok = status == 202
+    print(f"  {PASS if ok else FAIL} status={status}  期待=202")
+    if not ok:
+        print(f"     response: {body}")
+    # 成功したドキュメントはクリーンアップ
+    if ok and not DISABLE_CLEANUP and "id" in body:
+        _delete(client, body["id"])
+        print(f"     → doc_id={body['id']} を削除しました（クリーンアップ）")
+    return ok
+
+
+def scenario_size_over(client: httpx.Client) -> bool:
+    """[2] サイズ超過 (11MB) → 413"""
+    print("  （11MB ダミーファイルをメモリ上で生成中...）")
+    content = b"\x00" * (11 * 1024 * 1024)
+    status, body = _upload(client, "over_limit_11mb.bin", content, "application/pdf")
+    ok = status == 413
+    print(f"  {PASS if ok else FAIL} status={status}  期待=413")
+    if not ok:
+        print(f"     response: {body}")
+    return ok
+
+
+def scenario_page_over(client: httpx.Client) -> bool:
+    """[3] ページ数超過 (4ページ) → 422"""
+    content = _load_or_generate("over_limit_4page.pdf", lambda: _make_pdf_bytes(4))
+    status, body = _upload(client, "over_limit_4page.pdf", content, "application/pdf")
+    ok = status == 422
+    print(f"  {PASS if ok else FAIL} status={status}  期待=422")
+    if not ok:
+        print(f"     response: {body}")
+    return ok
+
+
+def scenario_corrupted_pdf(client: httpx.Client) -> bool:
+    """[4] 破損 PDF → 422"""
+    corrupted_path = FIXTURES_DIR / "corrupted.pdf"
+    if USE_FIXTURES and corrupted_path.exists():
+        content = corrupted_path.read_bytes()
+    else:
+        content = b"%PDF-1.4\n%%EOF\ncorrupted garbage data that pypdf cannot parse"
+    status, body = _upload(client, "corrupted.pdf", content, "application/pdf")
+    ok = status == 422
+    print(f"  {PASS if ok else FAIL} status={status}  期待=422")
+    if not ok:
+        print(f"     response: {body}")
+    return ok
+
+
+# ───────────────────────────────────────────────
+# メイン
+# ───────────────────────────────────────────────
+
+def main() -> None:
+    # 前提チェック
+    errors = []
+    if not API_URL:
+        errors.append("API_URL が未設定です")
+    if not FIREBASE_TOKEN:
+        errors.append("FIREBASE_TOKEN が未設定です（取得手順は UPLOAD_VALIDATION_GUIDE.md 参照）")
+    if errors:
+        for e in errors:
+            print(f"❌ {e}")
+        sys.exit(1)
+
+    print("=" * 55)
+    print("  アップロードバリデーション 手動検証")
+    print("=" * 55)
+    print(f"  API_URL     : {API_URL}")
+    print(f"  USE_FIXTURES: {USE_FIXTURES}")
+    print(f"  token       : {FIREBASE_TOKEN[:20]}...")
+    print("=" * 55)
+
+    headers = {"Authorization": f"Bearer {FIREBASE_TOKEN}"}
+
+    results: list[bool] = []
+    with httpx.Client(headers=headers) as client:
+
+        print("\n[1/4] 通常 PDF (1ページ, ~1KB) → 202 期待")
+        results.append(scenario_normal_pdf(client))
+        time.sleep(0.5)
+
+        print("\n[2/4] サイズ超過 (11MB) → 413 期待")
+        results.append(scenario_size_over(client))
+        time.sleep(0.5)
+
+        print("\n[3/4] ページ数超過 (4ページ) → 422 期待")
+        results.append(scenario_page_over(client))
+        time.sleep(0.5)
+
+        print("\n[4/4] 破損 PDF → 422 期待")
+        results.append(scenario_corrupted_pdf(client))
+
+    # サマリ
+    passed = sum(results)
+    total = len(results)
+    print("\n" + "=" * 55)
+    if passed == total:
+        print(f"  {PASS} 全シナリオ通過: {passed}/{total}")
+    else:
+        print(f"  {FAIL} 失敗あり: {passed}/{total} passed")
+        failed_indices = [i + 1 for i, ok in enumerate(results) if not ok]
+        print(f"     失敗したシナリオ: {failed_indices}")
+    print("=" * 55)
+
+    sys.exit(0 if passed == total else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -265,6 +265,7 @@ dependencies = [
     { name = "google-cloud-storage" },
     { name = "google-cloud-tasks" },
     { name = "icalendar" },
+    { name = "pypdf" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "pywebpush" },
@@ -296,6 +297,7 @@ requires-dist = [
     { name = "google-cloud-tasks", specifier = ">=2.20.0" },
     { name = "icalendar", specifier = ">=6.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "pypdf", specifier = ">=4.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
@@ -1628,6 +1630,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/a5/181488fc2b9d093e3972d2a472855aae8a03f000592dbfce716a512b3359/pyparsing-3.2.5.tar.gz", hash = "sha256:2df8d5b7b2802ef88e8d016a2eb9c7aeaa923529cd251ed0fe4608275d4105b6", size = 1099274 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/5e/1aa9a93198c6b64513c9d7752de7422c06402de6600a8767da1524f9570b/pyparsing-3.2.5-py3-none-any.whl", hash = "sha256:e38a4f02064cf41fe6593d328d0512495ad1f3d8a91c4f73fc401b3079a59a5e", size = 113890 },
+]
+
+[[package]]
+name = "pypdf"
+version = "6.7.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/dc/f52deef12797ad58b88e4663f097a343f53b9361338aef6573f135ac302f/pypdf-6.7.4.tar.gz", hash = "sha256:9edd1cd47938bb35ec87795f61225fd58a07cfaf0c5699018ae1a47d6f8ab0e3", size = 5304821 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/be/cded021305f5c81b47265b8c5292b99388615a4391c21ff00fd538d34a56/pypdf-6.7.4-py3-none-any.whl", hash = "sha256:527d6da23274a6c70a9cb59d1986d93946ba8e36a6bc17f3f7cce86331492dda", size = 331496 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **バックエンド**: `documents.py` にサイズ上限 10MB（413）・PDF ページ数上限 3 ページ（422）のバリデーションを追加。`pypdf` で PDF を読み取り、破損ファイルも 422 で弾く
- **フロントエンド**: `UploadArea.tsx` にクライアント側 10MB チェックを追加（即時フィードバック）。サーバーからの 413/422 エラーの `detail` メッセージをそのまま UI に表示
- **テスト**: ユニットテスト 6 件追加（サイズ超過・ページ数超過・破損PDF・正常系）、フロントエンド E2E 2 件追加、dev デプロイ後の手動検証スクリプト（`tests/manual/test_upload_validation.py`）を追加

## 環境変数（デフォルト値）

| 変数名 | デフォルト | 説明 |
|--------|-----------|------|
| `MAX_UPLOAD_SIZE_MB` | `10` | サイズ上限 (MB) |
| `MAX_PDF_PAGES` | `3` | PDF ページ数上限 |

## Test plan

- [x] `uv run python -m pytest tests/unit/test_api_documents.py -v` → 15 件全通過
- [x] `cd frontend && npm run test:e2e -- --project=chromium e2e/dashboard.spec.ts` → 3 件全通過
- [x] `uv run ruff check v2/ tests/` → エラーなし
- [ ] デプロイ後: `API_URL=... FIREBASE_TOKEN=... uv run python tests/manual/test_upload_validation.py` → 4/4 通過を確認（手順書: `tests/manual/UPLOAD_VALIDATION_GUIDE.md`）
  - デプロイ前は意図的に 1/4（シナリオ2〜4が202を返す）
  - デプロイ後は 4/4 になることで実装が有効になったと確認できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)