### PR TITLE
fix(cd): Terraform に渡す Docker イメージ URL を SHA/ダイジェストに変更

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -125,7 +125,7 @@ jobs:
           docker tag "${SHA_URL}" "${LATEST_URL}"
           docker push "${SHA_URL}"
           docker push "${LATEST_URL}"
-          echo "IMAGE_URL=${LATEST_URL}" >> $GITHUB_ENV
+          echo "IMAGE_URL=${SHA_URL}" >> $GITHUB_ENV
 
       - name: Get current image URL (Terraform-only change)
         # バックエンド変更なし → 現行の Cloud Run イメージ URL を引き継ぐ

--- a/.github/workflows/cd-prod-terraform.yml
+++ b/.github/workflows/cd-prod-terraform.yml
@@ -52,8 +52,13 @@ jobs:
         working-directory: terraform/environments/prod
         run: |
           LATEST_PROD_URL="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/school-agent-prod/school-agent-v2:latest-prod"
+          # latest-prod タグのダイジェスト付き URL を解決してユニークな URL を取得
+          # これにより Terraform がイメージの変更を確実に検出し新リビジョンを作成する
+          IMAGE_URL=$(gcloud artifacts docker images describe "${LATEST_PROD_URL}" \
+            --format="value(image_summary.fully_qualified_digest)" 2>/dev/null \
+            || echo "${LATEST_PROD_URL}")
           terraform apply -auto-approve \
-            -var="image_url=${LATEST_PROD_URL}" \
+            -var="image_url=${IMAGE_URL}" \
             -var="project_id=${{ env.PROJECT_ID }}" \
             -var="spreadsheet_id=${{ secrets.TF_VAR_SPREADSHEET_ID }}" \
             -var="inbox_folder_id=${{ secrets.TF_VAR_INBOX_FOLDER_ID }}" \


### PR DESCRIPTION
## Summary

- `latest` / `latest-prod` タグを使い続けると Terraform がテンプレート差分を検出できず、Cloud Run の新リビジョンが作成されないバグを修正
- コード変更をプッシュしても旧リビジョンが稼働し続ける根本原因（PR #84 のバリデーション未反映の原因）

## Changes

### `cd-dev.yml`
```diff
- echo "IMAGE_URL=${LATEST_URL}" >> $GITHUB_ENV
+ echo "IMAGE_URL=${SHA_URL}" >> $GITHUB_ENV
```
毎コミットでユニークな SHA タグ（例: `:95e3e8b`）を Terraform に渡すことで、確実に新リビジョンを作成する。`latest` タグへの push は引き続き実施（手動確認用）。

### `cd-prod-terraform.yml`
```diff
  LATEST_PROD_URL="...school-agent-v2:latest-prod"
+ IMAGE_URL=$(gcloud artifacts docker images describe "${LATEST_PROD_URL}" \
+   --format="value(image_summary.fully_qualified_digest)" 2>/dev/null \
+   || echo "${LATEST_PROD_URL}")
  terraform apply -auto-approve \
-   -var="image_url=${LATEST_PROD_URL}" \
+   -var="image_url=${IMAGE_URL}" \
```
prod は build/terraform が別ワークフローのため SHA を直接参照できない。代わりに `gcloud artifacts docker images describe` でダイジェスト付き URL（`registry@sha256:...`）に解決してから渡す。

## Test plan

- [ ] CI (lint + test) が通ることを確認
- [ ] main マージ後、Cloud Run のリビジョン一覧に新リビジョンが作成されることを確認
- [ ] 手動検証スクリプトで期待通りのレスポンスを確認:
  ```bash
  API_URL=https://... FIREBASE_TOKEN=eyJ... \
  uv run python tests/manual/test_upload_validation.py
  ```
  - テスト2 → 413、テスト3 → 422、テスト4 → 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)