### PR TITLE
feat(security): Firestore セキュリティルールを追加 (closes #66)

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -70,6 +70,7 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       terraform: ${{ steps.filter.outputs.terraform }}
       frontend: ${{ steps.filter.outputs.frontend }}
+      firestore_rules: ${{ steps.filter.outputs.firestore_rules }}
     steps:
       - uses: actions/checkout@v4
 
@@ -86,6 +87,9 @@ jobs:
               - 'terraform/**'
             frontend:
               - 'frontend/**'
+            firestore_rules:
+              - 'firestore.rules'
+              - 'firebase.json'
 
   deploy:
     needs: [lint, test, changes]
@@ -230,8 +234,28 @@ jobs:
       - name: Deploy to Firebase Hosting
         run: firebase deploy --only hosting --project ${{ env.PROJECT_ID }}
 
+  deploy-firestore-rules:
+    needs: [lint, test, changes]
+    if: needs.changes.outputs.firestore_rules == 'true'
+    runs-on: ubuntu-latest
+    environment: dev
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to GCP via Workload Identity Federation
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Deploy Firestore rules
+        run: firebase deploy --only firestore:rules --project ${{ env.PROJECT_ID }}
+
   notify:
-    needs: [lint, test, deploy, deploy-frontend]
+    needs: [lint, test, deploy, deploy-frontend, deploy-firestore-rules]
     if: always()
     uses: ./.github/workflows/_notify-slack.yml
     with:
@@ -240,7 +264,8 @@ jobs:
       # 各ジョブは success か skipped であれば正常（skipped = 変更なしでスキップ）
       result: ${{ (
           (needs.deploy.result == 'success' || needs.deploy.result == 'skipped') &&
-          (needs.deploy-frontend.result == 'success' || needs.deploy-frontend.result == 'skipped')
+          (needs.deploy-frontend.result == 'success' || needs.deploy-frontend.result == 'skipped') &&
+          (needs.deploy-firestore-rules.result == 'success' || needs.deploy-firestore-rules.result == 'skipped')
         ) && 'success' || 'failure' }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/cd-prod-terraform.yml
+++ b/.github/workflows/cd-prod-terraform.yml
@@ -65,13 +65,37 @@ jobs:
             -var="archive_folder_id=${{ secrets.TF_VAR_ARCHIVE_FOLDER_ID }}" \
             -var="notification_email=${{ secrets.TF_VAR_NOTIFICATION_EMAIL }}"
 
+  deploy-firestore-rules:
+    if: |
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    environment: prod
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to GCP via Workload Identity Federation
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Deploy Firestore rules
+        run: firebase deploy --only firestore:rules --project ${{ env.PROJECT_ID }}
+
   notify:
-    needs: [deploy]
+    needs: [deploy, deploy-firestore-rules]
     if: always()
     uses: ./.github/workflows/_notify-slack.yml
     with:
       environment: prod
       workflow_name: "CD Terraform (prod)"
-      result: ${{ needs.deploy.result }}
+      result: ${{ (
+          needs.deploy.result == 'success' &&
+          (needs.deploy-firestore-rules.result == 'success' || needs.deploy-firestore-rules.result == 'skipped')
+        ) && 'success' || 'failure' }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
       - "tests/**"
       - "pyproject.toml"
       - "uv.lock"
+      - "firestore.rules"
+      - "firebase.json"
       - ".github/workflows/ci.yml"
 
 jobs:
@@ -102,3 +104,40 @@ jobs:
 
       - name: Run E2E tests
         run: uv run pytest tests/e2e/ -m e2e -v
+
+  firestore-rules:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Start Firestore Emulator
+        run: |
+          firebase emulators:start --only firestore --project rules-test &
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:8080/ 2>/dev/null; then
+              echo "Firestore Emulator is ready"
+              exit 0
+            fi
+            echo "Waiting for emulator... ($i/30)"
+            sleep 1
+          done
+          echo "ERROR: Firestore Emulator did not start within 30 seconds"
+          exit 1
+
+      - name: Run Firestore rules tests
+        env:
+          FIRESTORE_EMULATOR_HOST: "127.0.0.1:8080"
+          PROJECT_ID: "rules-test"
+        run: bash scripts/test_firestore_rules.sh

--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,7 @@
 {
+  "firestore": {
+    "rules": "firestore.rules"
+  },
   "hosting": {
     "public": "frontend/out",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,11 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // All client SDK access is denied.
+    // Data access is exclusively via the backend API (Admin SDK),
+    // which bypasses security rules.
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/scripts/test_firestore_rules.sh
+++ b/scripts/test_firestore_rules.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Firestore セキュリティルール検証スクリプト
+#
+# 使い方:
+#   # dev 環境に対して実行（デフォルト）
+#   ./scripts/test_firestore_rules.sh
+#
+#   # prod 環境に対して実行
+#   PROJECT_ID=clearbag-prod ./scripts/test_firestore_rules.sh
+#
+#   # Firebase Emulator に対して実行（CI 用）
+#   FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 ./scripts/test_firestore_rules.sh
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-clearbag-dev}"
+
+# エミュレーター環境変数が設定されていれば emulator に、なければ本番 API に向ける
+if [ -n "${FIRESTORE_EMULATOR_HOST:-}" ]; then
+  BASE_URL="http://${FIRESTORE_EMULATOR_HOST}/v1/projects/${PROJECT_ID}/databases/(default)/documents"
+  TARGET="Emulator (${FIRESTORE_EMULATOR_HOST})"
+else
+  BASE_URL="https://firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/documents"
+  TARGET="Real Firestore (${PROJECT_ID})"
+fi
+
+PASSED=0
+FAILED=0
+
+assert_denied() {
+  local description="$1"
+  local http_code="$2"
+
+  if [ "$http_code" -eq 403 ] || [ "$http_code" -eq 401 ]; then
+    echo "  PASS: ${description} (HTTP ${http_code})"
+    PASSED=$((PASSED + 1))
+  else
+    echo "  FAIL: ${description} (HTTP ${http_code}, expected 403)"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+echo "=== Firestore Security Rules Test ==="
+echo "Target: ${TARGET}"
+echo ""
+
+# Test 1: Unauthenticated read on users collection
+code=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/users/test-user")
+assert_denied "Unauthenticated read on users" "$code"
+
+# Test 2: Unauthenticated write on users collection
+code=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X PATCH -H "Content-Type: application/json" \
+  -d '{"fields":{"name":{"stringValue":"hacker"}}}' \
+  "${BASE_URL}/users/test-user")
+assert_denied "Unauthenticated write on users" "$code"
+
+# Test 3: Unauthenticated read on families collection
+code=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/families/test-family")
+assert_denied "Unauthenticated read on families" "$code"
+
+# Test 4: Unauthenticated write on families collection
+code=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X PATCH -H "Content-Type: application/json" \
+  -d '{"fields":{"name":{"stringValue":"hacker-family"}}}' \
+  "${BASE_URL}/families/test-family")
+assert_denied "Unauthenticated write on families" "$code"
+
+# Test 5: Unauthenticated read on nested subcollection
+code=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/families/test-family/documents/test-doc")
+assert_denied "Unauthenticated read on nested subcollection" "$code"
+
+echo ""
+echo "Results: ${PASSED} passed, ${FAILED} failed"
+
+if [ "$FAILED" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- `firestore.rules` を新規作成し、全クライアント SDK アクセスを拒否（`allow read, write: if false`）
- `firebase.json` に `firestore` セクションを追加してルールファイルを紐付け
- `scripts/test_firestore_rules.sh` を追加（実環境・Emulator 両対応の curl ベース検証スクリプト）
- CI に `firestore-rules` ジョブ追加（Firebase Emulator でルールを自動検証）
- `cd-dev.yml` に `deploy-firestore-rules` ジョブ追加（`firestore.rules`/`firebase.json` 変更時のみ実行）
- `cd-prod-terraform.yml` に `deploy-firestore-rules` ジョブ追加（タグリリース時に毎回デプロイ）

## Background

フロントエンドに埋め込まれた Firebase Config を使えばクライアント SDK から Firestore を直接読み書きできるリスクがあった。ClearBag では全データアクセスをバックエンド API + Admin SDK 経由で行うため、全クライアントアクセスを拒否するルールで安全にブロックする。Admin SDK はセキュリティルールをバイパスするためバックエンドへの影響はゼロ。

## Test plan

- [x] `./scripts/test_firestore_rules.sh` を dev 環境に対して実行 → 5/5 PASS (HTTP 403)
- [ ] CI の `firestore-rules` ジョブが通ること
- [ ] main マージ後、`cd-dev.yml` の `deploy-firestore-rules` ジョブが実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)