### PR TITLE
fix(iam): WIF SA に firebaserules.admin ロールを追加

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -199,6 +199,7 @@ locals {
     "roles/datastore.owner",                 # Firestore 管理 (B2C)
     "roles/cloudtasks.admin",                # Cloud Tasks キュー管理 (B2C)
     "roles/firebasehosting.admin",           # Firebase Hosting デプロイ
+    "roles/firebaserules.admin",             # Firestore セキュリティルール デプロイ
   ]
 }
 

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -189,6 +189,7 @@ locals {
     "roles/iam.serviceAccountAdmin",         # SA の作成・管理
     "roles/iam.workloadIdentityPoolAdmin",   # WIF Pool/Provider の管理
     "roles/monitoring.admin",                # Cloud Monitoring アラートポリシー・通知チャンネル管理
+    "roles/firebaserules.admin",             # Firestore セキュリティルール デプロイ
   ]
 }
 


### PR DESCRIPTION
## Summary

- `cd-dev` の `deploy-firestore-rules` ジョブが `403 The caller does not have permission` で失敗していた
- WIF サービスアカウントに `roles/firebasehosting.admin` はあったが `roles/firebaserules.admin` が欠けていた
- dev/prod 両環境の Terraform IAM ロールリストに `roles/firebaserules.admin` を追加

## Root Cause

`firebaserules.googleapis.com` は Firebase Hosting とは別サービスのため、Hosting デプロイ権限（`roles/firebasehosting.admin`）では Firestore Rules API を呼べない。Firestore Rules のデプロイには `firebaserules.ruleSets.create` と `firebaserules.releases.update` 権限が必要で、これらは `roles/firebaserules.admin` に含まれる。

## Test plan

- [ ] CI が通ること
- [ ] main マージ後、Terraform apply で SA にロールが付与されること
- [ ] `cd-dev` の `deploy-firestore-rules` ジョブが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)