### PR TITLE
fix(wif): PR イベントで terraform plan CI が認証できるよう WIF 条件を緩和

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -176,7 +176,7 @@ module "workload_identity" {
   source        = "../../modules/workload_identity"
   project_id    = var.project_id
   github_repo   = "marufeuille/ClearBag"
-  ref_condition = "assertion.ref == 'refs/heads/main'"
+  ref_condition = "assertion.ref == 'refs/heads/main' || assertion.event_name == 'pull_request'"
 
   depends_on = [
     google_project_service.sts,


### PR DESCRIPTION
## Summary

- `terraform/environments/dev/main.tf` の `ref_condition` を変更し、`pull_request` イベントでも WIF 認証が通るよう修正
- `tf-cmt-dev.yml`（PR コメント付き terraform plan）が PR ブランチから正常動作するようになる

## 問題の背景

`tf-cmt-dev.yml` は `pull_request` イベントで動作するよう設計されているが、WIF Pool の `attribute_condition` が以下のみを許可していた：

```
assertion.repository == 'marufeuille/ClearBag' && (assertion.ref == 'refs/heads/main')
```

PR ブランチのOIDCトークンは `assertion.ref == 'refs/heads/main'` を満たさないため認証拒否されていた（PR #94 の CI 失敗が起点で発覚）。

## 変更内容

```hcl
# Before
ref_condition = "assertion.ref == 'refs/heads/main'"

# After
ref_condition = "assertion.ref == 'refs/heads/main' || assertion.event_name == 'pull_request'"
```

## セキュリティ評価

| 観点 | 評価 |
|---|---|
| フォーク PR | `pull_request` イベントではシークレット非公開（GitHub デフォルト制約）のため影響なし |
| `assertion.repository` チェック | `attribute_condition` と SA IAM binding の両方で `marufeuille/ClearBag` 限定は変わらない |
| `terraform apply` への影響 | `cd-dev.yml` は `refs/heads/main` のみで動作。今回の変更対象外 |
| 実質リスク増加 | ほぼゼロ（Write 権限保持者が plan を実行できるのみ） |

## Test plan

- [ ] main マージ後、`cd-dev.yml` が Terraform apply を実行し WIF Pool の `attribute_condition` が更新される
- [ ] 次回 terraform 関連ファイルを変更した PR で `terraform plan` CI が正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)