### PR TITLE
fix(billing): cloudbilling.googleapis.com API を有効化

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -360,12 +360,21 @@ resource "google_project_service" "billingbudgets" {
   disable_on_destroy = false
 }
 
+# google_billing_account_iam_member の API コールに cloudbilling.googleapis.com が必要
+resource "google_project_service" "cloudbilling" {
+  project            = var.project_id
+  service            = "cloudbilling.googleapis.com"
+  disable_on_destroy = false
+}
+
 # Billing Account レベルで GitHub Actions SA に costsManager を付与
 # （予算の作成・更新に必要。billing.admin は手動ブートストラップ済みが前提）
 resource "google_billing_account_iam_member" "github_actions_costs_manager" {
   billing_account_id = var.billing_account_id
   role               = "roles/billing.costsManager"
   member             = "serviceAccount:${module.workload_identity.service_account_email}"
+
+  depends_on = [google_project_service.cloudbilling]
 }
 
 module "billing_budget" {

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -211,12 +211,21 @@ resource "google_project_service" "billingbudgets" {
   disable_on_destroy = false
 }
 
+# google_billing_account_iam_member の API コールに cloudbilling.googleapis.com が必要
+resource "google_project_service" "cloudbilling" {
+  project            = var.project_id
+  service            = "cloudbilling.googleapis.com"
+  disable_on_destroy = false
+}
+
 # Billing Account レベルで GitHub Actions SA に costsManager を付与
 # （予算の作成・更新に必要。billing.admin は手動ブートストラップ済みが前提）
 resource "google_billing_account_iam_member" "github_actions_costs_manager" {
   billing_account_id = var.billing_account_id
   role               = "roles/billing.costsManager"
   member             = "serviceAccount:${module.workload_identity.service_account_email}"
+
+  depends_on = [google_project_service.cloudbilling]
 }
 
 module "billing_budget" {


### PR DESCRIPTION
## Summary

- `terraform/environments/dev/main.tf` と `prod/main.tf` に `google_project_service "cloudbilling"` を追加
- `google_billing_account_iam_member` に `depends_on = [google_project_service.cloudbilling]` を追加

## 問題の背景

PR #94 マージ後の `cd-dev.yml` Terraform apply で以下のエラーが発生：

```
Error: Error retrieving IAM policy for billing account "...":
googleapi: Error 403: Cloud Billing API has not been used in project ... before or it is disabled.
```

`google_billing_account_iam_member` は `cloudbilling.googleapis.com` API を使用するが、
`billingbudgets.googleapis.com`（予算管理用）とは別 API のため、個別に有効化が必要だった。

## Test plan

- [ ] main マージ後、`cd-dev.yml` の Terraform apply で `google_billing_budget.this` が正常に作成される
- [ ] GCP Console > Billing > Budgets & alerts で予算が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)