### PR TITLE
fix(billing): google_billing_account_iam_member を Terraform から削除

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -360,23 +360,17 @@ resource "google_project_service" "billingbudgets" {
   disable_on_destroy = false
 }
 
-# google_billing_account_iam_member の API コールに cloudbilling.googleapis.com が必要
+# google_billing_budget は cloudbilling.googleapis.com API を使用する
 resource "google_project_service" "cloudbilling" {
   project            = var.project_id
   service            = "cloudbilling.googleapis.com"
   disable_on_destroy = false
 }
 
-# Billing Account レベルで GitHub Actions SA に costsManager を付与
-# （予算の作成・更新に必要。billing.admin は手動ブートストラップ済みが前提）
-resource "google_billing_account_iam_member" "github_actions_costs_manager" {
-  billing_account_id = var.billing_account_id
-  role               = "roles/billing.costsManager"
-  member             = "serviceAccount:${module.workload_identity.service_account_email}"
-
-  depends_on = [google_project_service.cloudbilling]
-}
-
+# 注意: GitHub Actions SA への roles/billing.costsManager 付与は手動で行う
+# gcloud billing accounts add-iam-policy-binding BILLING_ACCOUNT_ID \
+#   --member="serviceAccount:github-actions-deploy@clearbag-dev.iam.gserviceaccount.com" \
+#   --role="roles/billing.costsManager"
 module "billing_budget" {
   source = "../../modules/billing_budget"
 
@@ -388,7 +382,7 @@ module "billing_budget" {
   depends_on = [
     google_project_iam_member.github_actions,
     google_project_service.billingbudgets,
-    google_billing_account_iam_member.github_actions_costs_manager,
+    google_project_service.cloudbilling,
   ]
 }
 


### PR DESCRIPTION
## Summary

- `google_billing_account_iam_member` リソースを dev/prod main.tf から削除
- `billing.costsManager` の付与は手動（gcloud コマンド）で実施する方針に変更
- コメントに手動手順を記載

## 問題の背景

`google_billing_account_iam_member` を Terraform 管理しようとしたが、循環依存が発生：

1. このリソースを作成/読み取りするには SA が `billing.accounts.getIamPolicy` (= `billing.admin`) を保有する必要がある
2. `billing.admin` 自体も Billing Account レベルの権限であり、付与には既存の `billing.admin` 保持者が必要
3. GitHub Actions SA は Project レベルの IAM のみ Terraform で管理できる

## 手動ブートストラップ（**初回のみ**）

```bash
# dev
gcloud billing accounts add-iam-policy-binding BILLING_ACCOUNT_ID \
  --member="serviceAccount:github-actions-deploy@clearbag-dev.iam.gserviceaccount.com" \
  --role="roles/billing.costsManager"
```

`roles/billing.costsManager` は `billing.budgets.*` のみ付与するため、`billing.admin` より最小権限。

## Test plan

- [ ] main マージ後、`cd-dev.yml` の Terraform apply で `google_billing_budget.this` が正常に作成される

🤖 Generated with [Claude Code](https://claude.com/claude-code)