### PR TITLE
fix(billing): budget_filter.projects にプロジェクト番号を使用

### DIFF
--- a/terraform/modules/billing_budget/main.tf
+++ b/terraform/modules/billing_budget/main.tf
@@ -2,12 +2,17 @@
 # GCP 予算アラート
 # ---------------------------------------------------------------------------
 
+# budget_filter.projects は "projects/{PROJECT_NUMBER}" 形式が必要
+data "google_project" "this" {
+  project_id = var.project_id
+}
+
 resource "google_billing_budget" "this" {
   billing_account = var.billing_account_id
   display_name    = "Monthly Budget - ${var.project_id}"
 
   budget_filter {
-    projects = ["projects/${var.project_id}"]
+    projects = ["projects/${data.google_project.this.number}"]
   }
 
   amount {


### PR DESCRIPTION
## Summary

- `terraform/modules/billing_budget/main.tf` に `data "google_project"` を追加
- `budget_filter.projects` を `"projects/${var.project_id}"` から `"projects/${data.google_project.this.number}"` に変更

## 問題の背景

GCP Billing Budget API の `budget_filter.projects` フィールドは `projects/{PROJECT_NUMBER}` 形式を要求するが、`var.project_id` はプロジェクト ID（`clearbag-dev` のような文字列）のため `400 Request contains an invalid argument` が発生していた。

## Test plan

- [ ] main マージ後、`cd-dev.yml` の Terraform apply で `google_billing_budget.this` が正常に作成される
- [ ] GCP Console > Billing > Budgets & alerts で予算（50/80/100/150% しきい値）が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)