### PR TITLE
fix(billing): currency_code を変数化して JPY に対応

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -377,6 +377,7 @@ module "billing_budget" {
   billing_account_id        = var.billing_account_id
   project_id                = var.project_id
   budget_amount             = var.budget_amount
+  currency_code             = var.currency_code
   notification_channel_name = module.monitoring.notification_channel_name
 
   depends_on = [

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -53,7 +53,13 @@ variable "billing_account_id" {
 }
 
 variable "budget_amount" {
-  description = "月次予算金額 (USD)"
+  description = "月次予算金額（currency_code で指定した通貨建て）"
   type        = number
   default     = 50
+}
+
+variable "currency_code" {
+  description = "予算通貨コード（請求アカウントの通貨と一致させること。例: JPY, USD）"
+  type        = string
+  default     = "JPY"
 }

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -228,6 +228,7 @@ module "billing_budget" {
   billing_account_id        = var.billing_account_id
   project_id                = var.project_id
   budget_amount             = var.budget_amount
+  currency_code             = var.currency_code
   notification_channel_name = module.monitoring.notification_channel_name
 
   depends_on = [

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -41,7 +41,13 @@ variable "billing_account_id" {
 }
 
 variable "budget_amount" {
-  description = "月次予算金額 (USD)"
+  description = "月次予算金額（currency_code で指定した通貨建て）"
   type        = number
   default     = 50
+}
+
+variable "currency_code" {
+  description = "予算通貨コード（請求アカウントの通貨と一致させること。例: JPY, USD）"
+  type        = string
+  default     = "JPY"
 }

--- a/terraform/modules/billing_budget/main.tf
+++ b/terraform/modules/billing_budget/main.tf
@@ -17,7 +17,7 @@ resource "google_billing_budget" "this" {
 
   amount {
     specified_amount {
-      currency_code = "USD"
+      currency_code = var.currency_code
       units         = tostring(var.budget_amount)
     }
   }

--- a/terraform/modules/billing_budget/variables.tf
+++ b/terraform/modules/billing_budget/variables.tf
@@ -21,6 +21,12 @@ variable "alert_thresholds" {
   default     = [0.5, 0.8, 1.0, 1.5]
 }
 
+variable "currency_code" {
+  description = "予算通貨コード（請求アカウントの通貨と一致させること）"
+  type        = string
+  default     = "USD"
+}
+
 variable "notification_channel_name" {
   description = "Cloud Monitoring 通知チャンネルのリソース名"
   type        = string


### PR DESCRIPTION
## Summary

- `google_billing_budget` の `specified_amount.currency_code` を `"USD"` ハードコードから変数化
- dev/prod 環境のデフォルト値を `"JPY"` に設定（日本の GCP 請求アカウントは JPY のため）
- `billing_budget` モジュール側のデフォルトは `"USD"` のまま（汎用性維持）

## 背景

PR #98 でプロジェクト番号形式を修正後も `400 Request contains an invalid argument` が継続。
Terraform plan の出力に `currency_code = "USD"` が含まれており、請求アカウントの通貨（JPY）と
不一致になっていることが原因と推定。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `terraform/modules/billing_budget/main.tf` | `currency_code = "USD"` → `currency_code = var.currency_code` |
| `terraform/modules/billing_budget/variables.tf` | `currency_code` 変数を追加（デフォルト `"USD"`） |
| `terraform/environments/dev/variables.tf` | `currency_code` 変数を追加（デフォルト `"JPY"`） |
| `terraform/environments/dev/main.tf` | `module "billing_budget"` に `currency_code = var.currency_code` を追加 |
| `terraform/environments/prod/variables.tf` | 同上 |
| `terraform/environments/prod/main.tf` | 同上 |

## Test plan

- [ ] `terraform plan` で `currency_code = "JPY"` が表示されることを確認
- [ ] `terraform apply` で `google_billing_budget` が正常に作成されることを確認
- [ ] GCP Console > Billing > Budgets & alerts で予算が表示されることを確認

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)