### PR TITLE
docs: CLAUDE.md にタスク管理（GitHub Projects）の記述を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,12 @@ FIRESTORE_EMULATOR_HOST=localhost:8080 uv run pytest tests/e2e/ -m e2e -v
 
 ## 6. コード変更 → PR → マージ → デプロイフロー
 
+### タスク管理
+
+- タスクは [GitHub Projects](https://github.com/users/marufeuille/projects/2/views/1) で管理している
+- Issue の作成・更新時は、GitHub Projects のステータスも併せて更新すること
+- `gh project item-edit` コマンドでプロジェクトボードのフィールドを更新できる
+
 **特に指定がない場合、以下のステップを順に実行すること。**
 
 ### ステップ 1: ブランチ作成・実装


### PR DESCRIPTION
## Summary

- セクション6「コード変更 → PR → マージ → デプロイフロー」に `### タスク管理` セクションを追加
- GitHub Projects のボード URL を明記し、Issue 作成・更新時にステータスも更新するよう指示を追加
- `gh project item-edit` コマンドでフィールド更新できることを明記

## Test plan

- [ ] CLAUDE.md のセクション6の構造が崩れていないこと（目視確認）
- [ ] タスク管理セクションが `**特に指定がない場合...**` の前に正しく追加されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)