### PR TITLE
fix(firebase): CSP に Google Sign-In 必須ドメインを追加

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -34,7 +34,7 @@
           },
           {
             "key": "Content-Security-Policy",
-            "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com https://identitytoolkit.googleapis.com; img-src 'self' data:; font-src 'self'; frame-ancestors 'none'"
+            "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://securetoken.googleapis.com; img-src 'self' data: https://*.googleusercontent.com; font-src 'self'; frame-src https://accounts.google.com https://*.firebaseapp.com; worker-src 'self'; frame-ancestors 'none'"
           },
           {
             "key": "Strict-Transport-Security",


### PR DESCRIPTION
## Summary

Firebase Auth の Google サインインに必要な外部ドメインが `script-src` / `frame-src` から欠落していたため `auth/internal-error` が発生していた問題を修正。

### 変更前
```
script-src 'self' 'unsafe-inline'
```

### 変更後（追加分）
| ディレクティブ | 追加ドメイン | 理由 |
|---|---|---|
| `script-src` | `https://apis.google.com` | Google Sign-In の OAuth ライブラリ読み込み |
| `script-src` | `https://www.gstatic.com` | Firebase reCAPTCHA ライブラリ |
| `frame-src` | `https://accounts.google.com` | OAuth ポップアップ/リダイレクト先 |
| `frame-src` | `https://*.firebaseapp.com` | Firebase Auth のフレーム |
| `connect-src` | `wss://*.firebaseio.com` | Realtime DB WebSocket 接続 |
| `connect-src` | `https://securetoken.googleapis.com` | Firebase ID トークンリフレッシュ |
| `img-src` | `https://*.googleusercontent.com` | Google アカウントのプロフィール画像 |
| `worker-src` | `'self'` | PWA Service Worker の明示的許可 |

## Test plan

- [ ] dev 環境でデプロイ後、Google サインインが正常に動作すること
- [ ] ブラウザコンソールに CSP エラーが出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)