### PR TITLE
fix(firebase): CSP connect-src に *.run.app 追加・firebase.json 変更時に Hosting 再デプロイ

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -87,6 +87,7 @@ jobs:
               - 'terraform/**'
             frontend:
               - 'frontend/**'
+              - 'firebase.json'  # Hosting ヘッダー (CSP 等) の変更も frontend デプロイで反映
             firestore_rules:
               - 'firestore.rules'
               - 'firebase.json'

--- a/firebase.json
+++ b/firebase.json
@@ -34,7 +34,7 @@
           },
           {
             "key": "Content-Security-Policy",
-            "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://securetoken.googleapis.com; img-src 'self' data: https://*.googleusercontent.com; font-src 'self'; frame-src https://accounts.google.com https://*.firebaseapp.com; worker-src 'self'; frame-ancestors 'none'"
+            "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://securetoken.googleapis.com https://*.run.app; img-src 'self' data: https://*.googleusercontent.com; font-src 'self'; frame-src https://accounts.google.com https://*.firebaseapp.com; worker-src 'self'; frame-ancestors 'none'"
           },
           {
             "key": "Strict-Transport-Security",


### PR DESCRIPTION
## Summary

- **CSP `connect-src` に `https://*.run.app` を追加**
  Cloud Run API への fetch が \"Refused to connect because it violates the document's Content Security Policy\" でブロックされていた問題を修正
- **`cd-dev.yml` の `frontend` フィルターに `firebase.json` を追加**
  `firebase.json` の変更（CSP ヘッダー等）は `deploy-frontend` ジョブ（`firebase deploy --only hosting`）で反映されるが、これまで `firestore_rules` フィルターにのみ含まれており `deploy-firestore-rules`（`--only firestore:rules`）しか実行されなかった。フィルターを修正して Hosting ヘッダーも確実に再デプロイされるようにする。

## Test plan

- [ ] デプロイ後、dev 環境でドキュメント一覧が取得できること（CSP エラーなし）
- [ ] Google サインインが正常に動作すること
- [ ] ブラウザコンソールに CSP エラーが出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)