### PR TITLE
fix(settings): プッシュ通知トグルのエラーを画面に表示する

### DIFF
--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -28,6 +28,7 @@ export default function SettingsPage() {
   const [inviting, setInviting] = useState(false);
   const [pushPermission, setPushPermission] = useState<NotificationPermission>("default");
   const [pushSupported, setPushSupported] = useState(true);
+  const [pushError, setPushError] = useState<string | null>(null);
 
   useEffect(() => {
     setPushSupported(isPushSupported());
@@ -45,6 +46,7 @@ export default function SettingsPage() {
   const handlePushToggle = async () => {
     if (!settings) return;
     setSaving(true);
+    setPushError(null);
     try {
       if (!settings.notification_web_push) {
         // ON: Push 許可取得 → バックエンド登録 → 設定更新
@@ -66,6 +68,8 @@ export default function SettingsPage() {
         setSaved(true);
         setTimeout(() => setSaved(false), 2000);
       }
+    } catch (e) {
+      setPushError(e instanceof Error ? e.message : "通知の設定に失敗しました");
     } finally {
       setSaving(false);
     }
@@ -299,6 +303,9 @@ export default function SettingsPage() {
                         <p className="text-xs text-orange-500 mt-0.5">
                           ブラウザの設定から通知を許可してください
                         </p>
+                      )}
+                      {pushError && (
+                        <p className="text-xs text-red-500 mt-0.5">{pushError}</p>
                       )}
                     </div>
                     <button


### PR DESCRIPTION
## Summary

- `handlePushToggle` に `catch` ブロックが欠落しており、VAPID 公開鍵未設定時に `subscribePush()` が throw したエラーが無音で飲み込まれていた
- `pushError` state を追加し、エラー発生時にトグル下にメッセージを表示するよう修正
- これにより「VAPID 公開鍵が設定されていません」等のエラーがユーザーに見えるようになる

## 根本原因

`NEXT_PUBLIC_VAPID_PUBLIC_KEY` が GitHub Secrets に未登録のため、ビルド時に空文字となり `subscribePush()` がエラーを throw していた。本 PR はエラーの可視化のみ対応。VAPID 鍵の登録手順は PR #104 の説明を参照。

## Test plan

- [ ] 設定ページでプッシュ通知トグルを ON にしたとき、エラーがあれば赤文字でメッセージが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)