### PR TITLE
fix(push): SW ready タイムアウトとコンソールエラーログを追加

### DIFF
--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -69,7 +69,9 @@ export default function SettingsPage() {
         setTimeout(() => setSaved(false), 2000);
       }
     } catch (e) {
-      setPushError(e instanceof Error ? e.message : "通知の設定に失敗しました");
+      const message = e instanceof Error ? e.message : "通知の設定に失敗しました";
+      console.error("[Push通知] エラー:", e);
+      setPushError(message);
     } finally {
       setSaving(false);
     }


### PR DESCRIPTION
## Summary

- `navigator.serviceWorker.ready` が Service Worker のインストール失敗時に永久待機するため、通知トグルが無音でフリーズする問題を修正
- `subscribePush()` / `unsubscribePush()` 両方に 10 秒タイムアウト (`Promise.race`) を追加
- `handlePushToggle` の catch ブロックに `console.error` を追加し、UI エラー表示に加えてブラウザコンソールにも出力

## 症状と原因

- トグルを押しても ON にならず、エラー表示もなく、API 呼び出しも発生しない
- Cloud Run ログに `POST /api/push-subscriptions` が一切現れない → ブラウザ側で処理がハング
- `navigator.serviceWorker.ready` は SW がアクティブになるまで無限に待機するため、SW インストールに問題があると catch に辿り着かない

## Test plan

- [ ] マージ後デプロイ → 設定ページでプッシュ通知トグルを ON にして動作確認
- [ ] SW エラーの場合、10 秒後に「Service Worker の準備がタイムアウトしました」が UI 表示 & コンソールに出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)