### PR TITLE
fix(push): SW登録をnext-pwaの自動注入から手動登録に切り替え

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -4,7 +4,7 @@ import withPWA from "next-pwa";
 const pwaConfig = withPWA({
   dest: "public",
   disable: process.env.NODE_ENV === "development",
-  register: true,
+  register: false,
   skipWaiting: true,
   customWorkerDir: "worker",
 });

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import ServiceWorkerRegistrar from "@/components/ServiceWorkerRegistrar";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -32,6 +33,7 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body className={`${inter.className} min-h-screen bg-gray-50`}>
+        <ServiceWorkerRegistrar />
         {children}
       </body>
     </html>

--- a/frontend/src/components/ServiceWorkerRegistrar.tsx
+++ b/frontend/src/components/ServiceWorkerRegistrar.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Service Worker を手動登録するクライアントコンポーネント。
+ *
+ * next-pwa v5.6.0 は Next.js 15 App Router + output:"export" 環境で
+ * SW 登録スクリプトの HTML 注入に失敗するため、このコンポーネントで代替する。
+ * development 環境では sw.js が生成されないため何もしない。
+ */
+export default function ServiceWorkerRegistrar() {
+  useEffect(() => {
+    if (
+      process.env.NODE_ENV === "development" ||
+      !("serviceWorker" in navigator)
+    ) {
+      return;
+    }
+
+    navigator.serviceWorker.register("/sw.js").catch((err) => {
+      console.error("[SW] 登録に失敗しました:", err);
+    });
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## 問題

プッシュ通知を有効化すると「Service Worker の準備がタイムアウトしました」エラーが発生していた。

原因: `next-pwa` v5.6.0 が Next.js 15 App Router + `output: "export"` 環境で SW 登録スクリプトの HTML 注入に失敗する。
`out/sw.js` は正しく生成されているが `index.html` に SW への参照がゼロ → `navigator.serviceWorker.ready` が永遠に resolve しない。

## 変更内容

- **`ServiceWorkerRegistrar.tsx` (新規)**: `useEffect` で `/sw.js` を手動登録するクライアントコンポーネント。`NODE_ENV === "development"` では何もしない
- **`layout.tsx`**: `<ServiceWorkerRegistrar />` を追加（全ルートで SW が登録される）
- **`next.config.ts`**: `register: false` に変更（壊れた自動注入を無効化）
- **`pushSubscription.ts`**: `navigator.serviceWorker.ready` → `ensureServiceWorker()` に変更。未登録時は `/sw.js` をフォールバック登録してから `pushManager` を利用する

## テスト

- `npm run build` — ビルド成功
- `npm run test:e2e` — 24件全パス（E2E は `NODE_ENV=development` のため `ServiceWorkerRegistrar` は無害）

## 検証手順（デプロイ後）

1. 設定ページでプッシュ通知トグルを ON → エラーが出ないことを確認
2. ブラウザ DevTools > Application > Service Workers で SW が登録されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)