### PR TITLE
fix(auth): モバイルGoogle認証をリダイレクト方式に切り替え

### DIFF
--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -10,7 +10,7 @@
 import { User, onAuthStateChanged } from "firebase/auth";
 import { useEffect, useState } from "react";
 
-import { auth, signInWithGoogle, signOut } from "@/lib/firebase";
+import { auth, getGoogleRedirectResult, signInWithGoogle, signOut } from "@/lib/firebase";
 
 interface AuthState {
   user: User | null;
@@ -34,6 +34,8 @@ export function useAuth(): AuthState & {
 
   useEffect(() => {
     if (IS_E2E) return;
+    // モバイルリダイレクト認証後の結果を処理する（失敗してもサイレントに無視）
+    getGoogleRedirectResult().catch(() => {});
     const unsubscribe = onAuthStateChanged(auth, (user) => {
       setState({ user, loading: false });
     });

--- a/frontend/src/lib/firebase.ts
+++ b/frontend/src/lib/firebase.ts
@@ -9,7 +9,9 @@ import { getApp, getApps, initializeApp } from "firebase/app";
 import {
   GoogleAuthProvider,
   getAuth,
+  getRedirectResult,
   signInWithPopup,
+  signInWithRedirect,
   signOut as fbSignOut,
 } from "firebase/auth";
 
@@ -26,10 +28,30 @@ const firebaseConfig = {
 const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApp();
 export const auth = getAuth(app);
 
-/** Google サインインポップアップを開く */
+/** モバイル端末かどうかを判定 */
+function isMobile(): boolean {
+  return /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
+/**
+ * Google サインイン
+ * - PC: ポップアップ方式
+ * - モバイル: リダイレクト方式（ポップアップはブロックされるため）
+ */
 export async function signInWithGoogle() {
   const provider = new GoogleAuthProvider();
+  if (isMobile()) {
+    return signInWithRedirect(auth, provider);
+  }
   return signInWithPopup(auth, provider);
+}
+
+/**
+ * リダイレクト認証後の結果を取得する。
+ * モバイルでのリダイレクト方式では、ページ再読み込み後にこれを呼ぶ必要がある。
+ */
+export async function getGoogleRedirectResult() {
+  return getRedirectResult(auth);
 }
 
 /** サインアウト */


### PR DESCRIPTION
## Summary

- モバイルブラウザ（Safari/Chrome on iOS/Android）では `signInWithPopup` がポップアップブロックにより動作しない問題を修正
- `isMobile()` でユーザーエージェントを判定し、モバイル時は `signInWithRedirect` → `getRedirectResult` フローに切り替え
- `useAuth.ts` でページロード時に `getRedirectResult()` を呼び出し、リダイレクト後の認証結果を自動処理

## 関連: VAPID キー形式修正（コード変更なし）

Cloud Run ログで `ValueError: Could not deserialize key data` が発生していた原因:
- Secret Manager に PEM 形式（`-----BEGIN PRIVATE KEY-----`）で保存されていた
- `py_vapid.from_string()` は base64url エンコードの DER 形式を期待している
- Secret Manager version 3 に正しい形式のキーを追加し、Cloud Run を再デプロイ済み

## Test plan

- [x] `npm run build` 成功
- [x] Playwright E2E 24件 全通過
- [ ] モバイル実機でGoogle認証が動作することを確認
- [ ] プッシュ通知が送信されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)