### PR TITLE
fix(auth): モバイルGoogle認証 - CSP修正・エラーログ追加

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -34,7 +34,7 @@
           },
           {
             "key": "Content-Security-Policy",
-            "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://securetoken.googleapis.com https://*.run.app; img-src 'self' data: https://*.googleusercontent.com; font-src 'self'; frame-src https://accounts.google.com https://*.firebaseapp.com; worker-src 'self'; frame-ancestors 'none'"
+            "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://securetoken.googleapis.com https://*.run.app https://accounts.google.com; img-src 'self' data: https://*.googleusercontent.com; font-src 'self'; frame-src https://accounts.google.com https://*.firebaseapp.com https://*.web.app; form-action 'self' https://accounts.google.com https://*.firebaseapp.com https://*.web.app; worker-src 'self'; frame-ancestors 'none'"
           },
           {
             "key": "Strict-Transport-Security",

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -34,8 +34,10 @@ export function useAuth(): AuthState & {
 
   useEffect(() => {
     if (IS_E2E) return;
-    // モバイルリダイレクト認証後の結果を処理する（失敗してもサイレントに無視）
-    getGoogleRedirectResult().catch(() => {});
+    // モバイルリダイレクト認証後の結果を処理する
+    getGoogleRedirectResult().catch((error) => {
+      console.error("[Auth] getRedirectResult failed:", error?.code, error?.message);
+    });
     const unsubscribe = onAuthStateChanged(auth, (user) => {
       setState({ user, loading: false });
     });


### PR DESCRIPTION
## 概要

モバイルブラウザ（特に iOS Safari）でのGoogle サインインが完了せずトップページに戻る問題への対処。

## 変更内容

### firebase.json（CSP修正）
- `form-action` ディレクティブを追加 — `signInWithRedirect` 時に `accounts.google.com` へのフォームナビゲーションが `default-src 'self'` にフォールバックしてブロックされるのを防ぐ
- `connect-src` に `https://accounts.google.com` を追加
- `frame-src` に `https://*.web.app` を追加（リダイレクト後のコールバック処理のため）

### useAuth.ts（エラーログ）
- `getGoogleRedirectResult().catch(() => {})` のサイレント握りつぶしを解消
- エラー発生時に `console.error("[Auth] getRedirectResult failed: ...")` でコードとメッセージをログ出力

## 残作業（手動操作が必要）

**Step 1（P0）: GitHub Secret `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` の変更**

| 環境 | 変更前 | 変更後 |
|---|---|---|
| dev | `clearbag-dev.firebaseapp.com` | `clearbag-dev.web.app` |

これが根本原因（iOS Safari の ITP がクロスオリジンのセッション受け渡しをブロック）の修正。

**前提確認**: Firebase Console > Authentication > Settings > Authorized domains に `clearbag-dev.web.app` が含まれていること。

## テスト計画

- [x] `npm run test:e2e` — 24件全通過（E2Eテストは Firebase Auth をバイパスするため既存回帰のみ）
- [ ] GitHub Secret 変更後、iOS Safari 実機で Google サインイン → `/dashboard` 遷移を確認
- [ ] デスクトップ Chrome/Safari でサインインが引き続き動作することを確認
- [ ] Safari Web Inspector コンソールで CSP 違反がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)