### PR TITLE
fix(auth): Android Chrome のサインインをポップアップ方式に修正

### DIFF
--- a/frontend/src/lib/firebase.ts
+++ b/frontend/src/lib/firebase.ts
@@ -28,19 +28,24 @@ const firebaseConfig = {
 const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApp();
 export const auth = getAuth(app);
 
-/** モバイル端末かどうかを判定 */
-function isMobile(): boolean {
-  return /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+/**
+ * iOS Safari かどうかを判定。
+ * iOS Safari はユーザー操作起点でもポップアップをブロックするため、
+ * リダイレクト方式が必要な唯一のケース。
+ * Android Chrome はユーザー操作起点のポップアップを許可する。
+ */
+function isIOSSafari(): boolean {
+  return /iPhone|iPad|iPod/i.test(navigator.userAgent);
 }
 
 /**
  * Google サインイン
- * - PC: ポップアップ方式
- * - モバイル: リダイレクト方式（ポップアップはブロックされるため）
+ * - PC / Android Chrome: ポップアップ方式
+ * - iOS Safari: リダイレクト方式（ポップアップがブロックされるため）
  */
 export async function signInWithGoogle() {
   const provider = new GoogleAuthProvider();
-  if (isMobile()) {
+  if (isIOSSafari()) {
     return signInWithRedirect(auth, provider);
   }
   return signInWithPopup(auth, provider);


### PR DESCRIPTION
## 概要

Android Chrome でログイン後にダッシュボードへ遷移できない問題を修正。

## 根本原因

`isMobile()` が Android + iOS を一括検出し、両方で `signInWithRedirect` を使っていた。しかし `signInWithRedirect` が必要なのは **iOS Safari** のみで、Android Chrome はユーザー操作起点のポップアップをブロックしない。

`signInWithRedirect` を Android で使うと `/__/auth/handler` 経由の複雑なリダイレクトフローが発生し、Service Worker のインターセプトや Firebase の認証結果保存タイミングの問題が起きやすい。

## 変更内容

`frontend/src/lib/firebase.ts`
- `isMobile()` → `isIOSSafari()` に変更（iOS デバイスのみ検出）
- Android Chrome: `signInWithPopup`（安定）
- iOS Safari: `signInWithRedirect`（ITP 対応のため必要）

## テスト計画

- [x] `npm run test:e2e` — 24件全通過
- [ ] Android Chrome で `https://clearbag-dev.web.app` → Googleサインイン → `/dashboard` 遷移を確認
- [ ] PC Chrome が引き続き正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)