### PR TITLE
fix(auth): register_with_code で Custom Claims を設定し灰色画面を修正

### DIFF
--- a/tests/unit/test_api_auth.py
+++ b/tests/unit/test_api_auth.py
@@ -148,12 +148,53 @@ class TestRegisterWithCode:
             patch(
                 "v2.entrypoints.api.routes.auth.firestore.transactional", lambda fn: fn
             ),
+            patch(
+                "v2.entrypoints.api.routes.auth.fb_auth.set_custom_user_claims"
+            ) as mock_claims,
         ):
             response = client.post("/api/auth/register", json={"code": _VALID_CODE})
 
         assert response.status_code == 200
         assert response.json()["activated"] is True
         assert response.json()["already_activated"] is False
+        # Custom Claims が正しいパラメータで呼ばれること（Cold Start 回避のため必須）
+        mock_claims.assert_called_once_with(_UID, {"is_activated": True})
+
+    def test_successful_activation_claims_failure_is_nonfatal(self, client: TestClient):
+        # Arrange: Custom Claims 設定が失敗しても 200 を返すこと
+        code_snap = _make_code_snap(
+            {"expires_at": _FUTURE, "used_count": 0, "max_uses": 10}
+        )
+        user_snap = _make_user_snap(is_activated=False)
+
+        mock_db = MagicMock()
+        mock_coll = MagicMock()
+        mock_db.collection.return_value = mock_coll
+        mock_coll.document.return_value.get.side_effect = [
+            code_snap,
+            user_snap,
+            code_snap,
+        ]
+        mock_db.transaction.return_value = MagicMock()
+
+        with (
+            patch(
+                "v2.entrypoints.api.routes.auth._get_firestore_client",
+                return_value=mock_db,
+            ),
+            patch(
+                "v2.entrypoints.api.routes.auth.firestore.transactional", lambda fn: fn
+            ),
+            patch(
+                "v2.entrypoints.api.routes.auth.fb_auth.set_custom_user_claims",
+                side_effect=Exception("Firebase Auth unavailable"),
+            ),
+        ):
+            response = client.post("/api/auth/register", json={"code": _VALID_CODE})
+
+        # Custom Claims 失敗は non-fatal — Firestore への is_activated 設定は完了済み
+        assert response.status_code == 200
+        assert response.json()["activated"] is True
 
     def test_unlimited_code_succeeds(self, client: TestClient):
         # Arrange: max_uses=None（無制限コード）
@@ -181,6 +222,7 @@ class TestRegisterWithCode:
             patch(
                 "v2.entrypoints.api.routes.auth.firestore.transactional", lambda fn: fn
             ),
+            patch("v2.entrypoints.api.routes.auth.fb_auth.set_custom_user_claims"),
         ):
             response = client.post("/api/auth/register", json={"code": _VALID_CODE})
 

--- a/v2/entrypoints/api/routes/auth.py
+++ b/v2/entrypoints/api/routes/auth.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import datetime
 import logging
 
+import firebase_admin.auth as fb_auth
 from fastapi import APIRouter, Depends, HTTPException, status
 from google.cloud import firestore
 from pydantic import BaseModel
@@ -106,6 +107,15 @@ def register_with_code(
 
     transaction = db.transaction()
     _activate(transaction)
+
+    # Custom Claims を設定 — 次回 JWT 取得時にフロントエンドが API 呼び出し不要で
+    # is_activated を確認できるようにする（Cold Start 回避）
+    try:
+        fb_auth.set_custom_user_claims(auth_info.uid, {"is_activated": True})
+    except Exception:
+        logger.warning(
+            "Failed to set custom claims for uid=%s (non-fatal)", auth_info.uid
+        )
 
     logger.info(
         "register_with_code: activated uid=%s code=%s",


### PR DESCRIPTION
## Summary

- `POST /api/auth/register`（サービスコード登録）後に Firebase Custom Claims (`is_activated: true`) が設定されていなかったバグを修正
- キャッシュ（24h TTL）切れのたびに `getFamily()` API フォールバックが発生し、Cloud Run Cold Start 中に灰色画面（AppSkeleton）が長時間表示される問題を解消
- `families.py` の `join_family()` と同じパターン（トランザクション後・失敗 non-fatal）を適用

## 根本原因

| 登録経路 | Firestore | Custom Claims | 修正前の灰色画面リスク |
|---|---|---|---|
| `POST /api/families/join`（招待リンク） | ✅ | ✅ | 低 |
| `scripts/activate_existing_users.py` | ✅ | ✅ | 低 |
| **`POST /api/auth/register`（サービスコード）** | ✅ | ❌ → **✅** | 高 → **解消** |

## Test plan

- [x] `uv run pytest tests/unit/test_api_auth.py -v` — 7件全パス（新規2件含む）
- [x] `uv run pytest tests/unit/ -m "not manual" -v` — 215件全パス
- [x] `make lint` — lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)